### PR TITLE
fix: migration to 2022 fails with compilation error

### DIFF
--- a/CHANGELOG-gui.md
+++ b/CHANGELOG-gui.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog].
 ### Removed
 
 ### Fixed
+- Unity 2022 Migration can be fails with Compilation Error `#712`
 
 ### Security
 

--- a/vrc-get-gui/src/commands.rs
+++ b/vrc-get-gui/src/commands.rs
@@ -2107,6 +2107,7 @@ async fn project_finalize_migration_with_unity_2022<R: Runtime>(
             .args([
                 "-quit".as_ref(),
                 "-batchmode".as_ref(),
+                "-ignorecompilererrors".as_ref(),
                 // https://docs.unity3d.com/Manual/EditorCommandLineArguments.html
                 "-logFile".as_ref(),
                 "-".as_ref(),


### PR DESCRIPTION
Fixes #711 