### PR TITLE
chore(gui)(ja/en): add i18n text "language"

### DIFF
--- a/vrc-get-gui/locales/en.json5
+++ b/vrc-get-gui/locales/en.json5
@@ -200,5 +200,6 @@
     "creating a backup...": "Creating a backup...",
     "backup canceled": "Backup canceled",
     "backup created successfully": "Backup created successfully",
+     "language": "Language",
   },
 }

--- a/vrc-get-gui/locales/en.json5
+++ b/vrc-get-gui/locales/en.json5
@@ -200,6 +200,6 @@
     "creating a backup...": "Creating a backup...",
     "backup canceled": "Backup canceled",
     "backup created successfully": "Backup created successfully",
-     "language": "Language",
+    "language": "Language",
   },
 }

--- a/vrc-get-gui/locales/ja.json5
+++ b/vrc-get-gui/locales/ja.json5
@@ -191,5 +191,6 @@
     "creating a backup...": "バックアップを作成中...",
     "backup canceled": "バックアップをキャンセルしました。",
     "backup created successfully": "バックアップを作成しました。",
+    "language": "言語設定(Language)",
   },
 }


### PR DESCRIPTION
Add i18n text to "Settings"/ "language".
before:
![image](https://github.com/vrc-get/vrc-get/assets/10654237/2522e4fb-8655-40e2-b8d2-4895ca731417)
en: Language
![image](https://github.com/vrc-get/vrc-get/assets/10654237/f7ff6b88-b580-4c3c-a33f-74919313ae95)
jp: 言語設定(Language)
![image](https://github.com/vrc-get/vrc-get/assets/10654237/7b12fce7-9841-4312-8f9e-f8601392a9ce)

close #738 