### PR TITLE
feat(vrc-get-vpm): add `/opt/unityhub/unityhub` for detection candidate

### DIFF
--- a/CHANGELOG-gui.md
+++ b/CHANGELOG-gui.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 ### Added
+- `/opt/unityhub/unityhub` to the unity hub search path `#812`
+  - The path is the default path for official apt distribution
 
 ### Changed
 

--- a/vrc-get-vpm/src/environment/unity_management.rs
+++ b/vrc-get-vpm/src/environment/unity_management.rs
@@ -114,8 +114,8 @@ impl<T: HttpClient, IO: EnvironmentIo> Environment<T, IO> {
                     let home = std::env::var("HOME").expect("HOME not set");
                     format!("{}/Applications/Unity Hub.AppImage", home)
                 };
-                static ref INSTALLATIONS: [&'static str; 2] =
-                    [&USER_INSTALLATION, "/usr/bin/unity-hub"];
+                static ref INSTALLATIONS: [&'static str; 3] =
+                    [&USER_INSTALLATION, "/usr/bin/unity-hub", "/opt/unityhub/unityhub"];
             }
 
             INSTALLATIONS.as_ref()


### PR DESCRIPTION
This commit allows the detection method to include binary via [their official](https://docs.unity3d.com/hub/manual/InstallHub.html#install-hub-linux) APT distribution.