### PR TITLE
German translation: Add "projects:type:sdk2"

### DIFF
--- a/vrc-get-gui/locales/de.json5
+++ b/vrc-get-gui/locales/de.json5
@@ -28,6 +28,7 @@
     "projects:last modified:years_one": "Vor einem Jahr",
     "projects:last modified:years_other": "Vor {{count}} Jahren",
     "projects:type:unknown": "Unbekannt",
+    "projects:type:sdk2": "SDK2",
     "projects:type:worlds": "Welt",
     "projects:type:avatars": "Avatar",
     "general:loading...": "Laden...",


### PR DESCRIPTION
Adds new key `projects:type:sdk2` from #869 to the german translation file.

SDK2 doesn't need translation, so this is just for completions-sake.

Ready to merge.