### PR TITLE
docs: add contributing guide link and update clone command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,5 +31,5 @@ For Windows machines, you need to setup so your current user can create symbolic
 To setup your project, use the following commands.
 
 ```bash
-git clone --recurse-submodules -c core.symlinks=true https://github.com/vrc-get/vrc-get.git
+git clone --recurse-submodules https://github.com/vrc-get/vrc-get.git
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,5 +31,5 @@ For Windows machines, you need to setup so your current user can create symbolic
 To setup your project, use the following commands.
 
 ```bash
-git clone --recurse-submodules https://github.com/vrc-get/vrc-get
+git clone --recurse-submodules -c core.symlinks=true https://github.com/vrc-get/vrc-get.git
 ```

--- a/README.md
+++ b/README.md
@@ -162,3 +162,8 @@ See [README of ALCOM][alcom] for more details.
 [homebrew-vrc-get]: https://formulae.brew.sh/formula/vrc-get
 [macports-vrc-get]: https://ports.macports.org/port/vrc-get
 [scoop-vrc-get]: https://github.com/babo4d/scoop-xrtools/blob/master/bucket/vrc-get.json
+
+## Contribution
+
+- For how to contribute vrc-get: [CONTRIBUTING.md](CONTRIBUTING.md)
+- For how to contribute localization to ALCOM (vrc-get-gui): [vrc-get-gui/CONTRIBUTING.md](vrc-get-gui/CONTRIBUTING.md) (**Please read [CONTRIBUTING.md#configuration-requirements](CONTRIBUTING.md#configuration-requirements) first before you read [vrc-get-gui/CONTRIBUTING.md](vrc-get-gui/CONTRIBUTING.md)!**)

--- a/vrc-get-gui/CONTRIBUTING.md
+++ b/vrc-get-gui/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing
 
+**Please read [../CONTRIBUTING.md#configuration-requirements](../CONTRIBUTING.md#configuration-requirements) first!**
+
 ## Localizing
 
 This project is internationalized, so when you add some text contents to the project, 

--- a/vrc-get-gui/README.md
+++ b/vrc-get-gui/README.md
@@ -37,3 +37,7 @@ npm run tauri build
 ALCOM is currently based on tauri and next.js.
 
 Run `npm run tauri dev` to start the development server and gui.
+
+## Contribution
+
+For how to contribute localization to ALCOM (vrc-get-gui): [CONTRIBUTING.md](CONTRIBUTING.md) (**Please read [../CONTRIBUTING.md#configuration-requirements](.../CONTRIBUTING.md#configuration-requirements) first before you read [CONTRIBUTING.md](CONTRIBUTING.md)!**)

--- a/vrc-get-gui/README.md
+++ b/vrc-get-gui/README.md
@@ -40,4 +40,4 @@ Run `npm run tauri dev` to start the development server and gui.
 
 ## Contribution
 
-For how to contribute localization to ALCOM (vrc-get-gui): [CONTRIBUTING.md](CONTRIBUTING.md) (**Please read [/CONTRIBUTING.md#configuration-requirements](.../CONTRIBUTING.md#configuration-requirements) first before you read [CONTRIBUTING.md](CONTRIBUTING.md)!**)
+For how to contribute localization to ALCOM (vrc-get-gui): [CONTRIBUTING.md](CONTRIBUTING.md) (**Please read [../CONTRIBUTING.md#configuration-requirements](../CONTRIBUTING.md#configuration-requirements) first before you read [CONTRIBUTING.md](CONTRIBUTING.md)!**)

--- a/vrc-get-gui/README.md
+++ b/vrc-get-gui/README.md
@@ -40,4 +40,4 @@ Run `npm run tauri dev` to start the development server and gui.
 
 ## Contribution
 
-For how to contribute localization to ALCOM (vrc-get-gui): [CONTRIBUTING.md](CONTRIBUTING.md) (**Please read [../CONTRIBUTING.md#configuration-requirements](.../CONTRIBUTING.md#configuration-requirements) first before you read [CONTRIBUTING.md](CONTRIBUTING.md)!**)
+For how to contribute localization to ALCOM (vrc-get-gui): [CONTRIBUTING.md](CONTRIBUTING.md) (**Please read [/CONTRIBUTING.md#configuration-requirements](.../CONTRIBUTING.md#configuration-requirements) first before you read [CONTRIBUTING.md](CONTRIBUTING.md)!**)


### PR DESCRIPTION
Since many tanslator report (to me) that.... they can't find the way to solve the symlinks and git submoduels problem. (because they are unfamiliar with tools like git and didn't find that there was a CONTRIBUTING.md file....)

I made a pull request to add CONTRIBUTING.md link to each README.md. And update the root CONTRIBUTING.md file clone command to make sure that, symlinks is create correctly (instead of a plain text file with file path)

and maybe we need to consider that add a guide for translator to teach them build a develope environment to see translation change real time?