### PR TITLE
German translation: Add vcc scheme dialog support.

### DIFF
--- a/vrc-get-gui/locales/de.json5
+++ b/vrc-get-gui/locales/de.json5
@@ -31,7 +31,6 @@
     "projects:type:sdk2": "SDK2",
     "projects:type:worlds": "Welt",
     "projects:type:avatars": "Avatar",
-    // "custom" is for new project type
     "projects:type:custom": "Eigene Vorlagen",
     "general:loading...": "Laden...",
     "projects:error:load error": "Fehler beim Laden der Projekte: {{msg}}",
@@ -197,6 +196,10 @@
     "settings:unity:path": "Pfad",
     "settings:unity:source:manual": "Benutzerdefiniert",
     "settings:unity:source:unity hub": "Unity Hub",
+    "settings:vcc scheme": "<code>vcc:</code> Linktyp Zuweisung",
+    "settings:vcc scheme description": "Der <code>vcc:</code> Linktyp wird verwendet, um VCC-Paketlisten direkt vom Browser aus hinzufügen zu können.<br>Als alternative zu VCC kann ALCOM diese Anfragen annehmen.<br>Unter MacOS geschieht dies automatisch. Andere Betriebssysteme müssen dies manuell festlegen.",
+    "settings:register vcc scheme": "ALCOM zum öffnen von <code>vcc:</code> Linktypen registrieren",
+    "settings:toast:vcc scheme installed": "ALCOM wurde als Programm für <code>vcc:</code> Linktypen registriert.",
     "general:toast:not supported": "{{name}} wird noch nicht unterstützt",
     "general:not implemented": "Nicht implementiert",
     "projects:toast:invalid project unity version": "Wir konnten keine gültige Unity Installation finden",


### PR DESCRIPTION
Implements vcc scheme dialog translations to german.
```
"settings:vcc scheme": "<code>vcc:</code> Linktyp Zuweisung",
"settings:vcc scheme description": "Der <code>vcc:</code> Linktyp wird verwendet, um VCC-Paketlisten direkt vom Browser aus hinzufügen zu können.<br>Als alternative zu VCC kann ALCOM diese Anfragen annehmen.<br>Unter MacOS geschieht dies automatisch. Andere Betriebssysteme müssen dies manuell festlegen.",
"settings:register vcc scheme": "ALCOM zum öffnen von <code>vcc:</code> Linktypen registrieren",
"settings:toast:vcc scheme installed": "ALCOM wurde als Programm für <code>vcc:</code> Linktypen registriert.",
```

The translation uses Windows German term for those links, which works better in that language.