### PR TITLE
chore(i18n/de): Add theme keys

### DIFF
--- a/vrc-get-gui/locales/de.json5
+++ b/vrc-get-gui/locales/de.json5
@@ -216,5 +216,9 @@
     "settings:language": "Sprache",
     "settings:report issue": "Problembehandlung",
     "settings:button:open issue": "Fehler melden",
+    "settings:theme": "Design",
+    "settings:theme:system": "System",
+    "settings:theme:light": "Hell",
+    "settings:theme:dark": "Dunkel",
   },
 }


### PR DESCRIPTION
Adds keys for the new theme selector.
Using the word Design is more common in German translations.
```
"settings:theme": "Design",
"settings:theme:system": "System",
"settings:theme:light": "Hell",
"settings:theme:dark": "Dunkel",
```