### PR TITLE
fix(gui/linux): vcc link installation fails on linux

### DIFF
--- a/CHANGELOG-gui.md
+++ b/CHANGELOG-gui.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog].
 ### Fixed
 - Unity from Unity Hub will be registered as manually registered Unity `#1081`
 - Unity selector radio button does not work well `#1082`
+- `vcc:` link install button does not work well on linux `#1117`
 
 ### Security
 

--- a/vrc-get-gui/src/deep_link_support.rs
+++ b/vrc-get-gui/src/deep_link_support.rs
@@ -177,6 +177,7 @@ Categories=Utility;
     log::info!("Desktop file created: {}", desktop_file.display());
 
     if let Err(e) = tokio::process::Command::new("update-desktop-database")
+        .arg(applications_dir)
         .status()
         .await
     {


### PR DESCRIPTION
Fixes #1093 