### PR TITLE
fix: correct typo

### DIFF
--- a/CHANGELOG-gui.md
+++ b/CHANGELOG-gui.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog].
 
 ### Fixed
 - Clicking VCC link while adding vpm repository would close previously opened add repository dialog `#1570`
+- Correct typo in `projects:dialog:vpm migrate description` [`#1578`](https://github.com/vrc-get/vrc-get/pull/1578)
 
 ### Security
 

--- a/CHANGELOG-gui.md
+++ b/CHANGELOG-gui.md
@@ -27,7 +27,6 @@ The format is based on [Keep a Changelog].
 
 ### Fixed
 - Clicking VCC link while adding vpm repository would close previously opened add repository dialog `#1570`
-- Correct typo in `projects:dialog:vpm migrate description` [`#1578`](https://github.com/vrc-get/vrc-get/pull/1578)
 
 ### Security
 

--- a/vrc-get-gui/locales/en.json5
+++ b/vrc-get-gui/locales/en.json5
@@ -152,7 +152,7 @@
     "projects:tooltip:sdk2 migration hint": "Legacy SDK2 project cannot be migrated automatically.<br>Please migrate to SDK3 manually first.",
     "projects:tooltip:git-vcc not supported": "git-VCC projects are not supported.",
     "projects:dialog:vpm migrate header": "Migrate legacy project",
-    "projects:dialog:vpm migrate description": "Migrating project might loose your changes. Please make a backup of your project before migration.",
+    "projects:dialog:vpm migrate description": "Migrating project might lose your changes. Please make a backup of your project before migration.",
     "projects:button:backup and migrate": "Backup and Migrate",
     "projects:button:migrate copy": "Migrate a Copy",
     "projects:button:migrate in-place": "Migrate in-place",


### PR DESCRIPTION
`"projects:dialog:vpm migrate description": "Migrating project might loose your changes. Please make a backup of your project before migration."`

correct `loose` to `lose`