### PR TITLE
fix: opening Templates folder fails if not exists

### DIFF
--- a/CHANGELOG-gui.md
+++ b/CHANGELOG-gui.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog].
 
 ### Fixed
 - Clicking VCC link while adding vpm repository would close previously opened add repository dialog `#1570`
+- Opnening Templetes directory might fails `#1641`
 
 ### Security
 

--- a/vrc-get-gui/app/(main)/settings/page.tsx
+++ b/vrc-get-gui/app/(main)/settings/page.tsx
@@ -34,6 +34,7 @@ import {
 import { assertNever } from "@/lib/assert-never";
 import type {
 	CheckForUpdateResponse,
+	OpenOptions,
 	TauriEnvironmentSettings,
 } from "@/lib/bindings";
 import { commands } from "@/lib/bindings";
@@ -510,12 +511,15 @@ function AppearanceCard() {
 }
 
 function FilesAndFoldersCard() {
-	const openVpmFolderContent = (subPath: string) => {
+	const openVpmFolderContent = (
+		subPath: string,
+		ifNotExists: OpenOptions = "ErrorIfNotExists",
+	) => {
 		return async () => {
 			try {
 				await commands.utilOpen(
 					`${globalInfo.vpmHomeFolder}/${subPath}`,
-					"ErrorIfNotExists",
+					ifNotExists,
 				);
 			} catch (e) {
 				console.error(e);
@@ -538,7 +542,9 @@ function FilesAndFoldersCard() {
 				<Button onClick={openVpmFolderContent("vrc-get/gui-logs")}>
 					{tc("settings:button:open logs")}
 				</Button>
-				<Button onClick={openVpmFolderContent("Templates")}>
+				<Button
+					onClick={openVpmFolderContent("Templates", "CreateFolderIfNotExists")}
+				>
 					{tc("settings:button:open custom templates")}
 				</Button>
 			</div>


### PR DESCRIPTION
Fix #1597 