### PR TITLE
docs: update README for ALCOM, adds Platform Version Policy and remove experimental

### DIFF
--- a/vrc-get-gui/README.md
+++ b/vrc-get-gui/README.md
@@ -1,17 +1,39 @@
-# ALCOM (experimental)
+# ALCOM
 
-This folder contains the experimental GUI version of vrc-get, ALCOM.
+This folder contains the GUI version of vrc-get, ALCOM.
 
 [Homepage (Help Wanted)](https://vrc-get.anatawa12.com/alcom/)
 
 ## Installation
 
-The recommended way to install ALCOM is download from [GitHub Releases][alcom-releases].
+The recommended way to install ALCOM is download from [Website][alcom-site].
 
 If you want, you may download the HEAD build from [GitHub Actions][alcom-nightly]
 
-[alcom-releases]: https://github.com/anatawa12/vrc-get/releases?q=gui-v0
+[alcom-site]: https://vrc-get.anatawa12.com/alcom/
 [alcom-nightly]: https://github.com/vrc-get/vrc-get/actions/workflows/ci-gui.yml?query=branch%3Amaster
+
+## Supported Platforms
+
+ALCOM runs on macOS, Windows, and Linux.
+
+We support modern versions of the platforms.
+Basically, we support the versions that the platform vendor supports.
+
+Here are detailed version support policies for each platform:
+Version numbers shown here are as of the writing (Dec 2024), so might be outdated.
+
+- macOS: We support the latest version of macOS that is available for non-vintage and non-obsoleted Macs.\
+  This means currently we support macOS 13 (Ventura) or later.
+  On macOS, we use WKWebView, which is built-in to macOS, so no additional requirements are needed.
+- Windows: We support the latest version of Windows that is supported as mainstream by Microsoft.\
+  This means currently we support Windows 10 21H2 or later and Windows 11 23H2 or later.
+  On windows, we use WebView2 so WebView2 should also be updated to supported versions.
+  Currently, WebView2 with Edge 130 or later is supported.
+- Linux: Linux is not well-supported, Linux support is best-effort by the community.\
+  No maintainer is using Linux as a primary platform, so we can't guarantee the quality of the Linux version.\
+  No specific version is guaranteed to work, but we will try to fix issues with your help.\
+  Basically, modern webkit2gtk 4.1 is required to run ALCOM since we use modern web features.
 
 ## Requirements (building)
 
@@ -50,3 +72,7 @@ Run `npm run tauri dev` to start the development server and gui.
 ## Contribution
 
 For how to contribute localization to ALCOM (vrc-get-gui): [CONTRIBUTING.md](CONTRIBUTING.md) (**Please read [../CONTRIBUTING.md#configuration-requirements](../CONTRIBUTING.md#configuration-requirements) first before you read [CONTRIBUTING.md](CONTRIBUTING.md)!**)
+
+## License
+
+ALCOM is licensed under the MIT License. See [LICENSE](../LICENSE) for more information.

--- a/vrc-get-gui/README.md
+++ b/vrc-get-gui/README.md
@@ -20,6 +20,10 @@ ALCOM runs on macOS, Windows, and Linux.
 We support modern versions of the platforms.
 Basically, we support the versions that the platform vendor supports.
 
+This support policy is to describe how my limited development resources use so it's welcome
+to pull requests that ports ALCOM to an older version of OSes.
+However, I won't maintain the backports so may break at any moment, I'll try to not break as possible though.
+
 Here are detailed version support policies for each platform:
 Version numbers shown here are as of the writing (Dec 2024), so might be outdated.
 


### PR DESCRIPTION
Closes #1399 since Mojave is completely unsupported version as of this version support policy.