### PR TITLE
Remove uppercase from Button component

### DIFF
--- a/vrc-get-gui/components/ui/button.tsx
+++ b/vrc-get-gui/components/ui/button.tsx
@@ -10,21 +10,21 @@ const buttonVariants = cva(
 		variants: {
 			variant: {
 				default:
-					"bg-primary text-primary-foreground hover:bg-primary/90 shadow-primary/50 hover:shadow-primary/50 shadow hover:shadow-md transition-shadow uppercase",
+					"bg-primary text-primary-foreground hover:bg-primary/90 shadow-primary/50 hover:shadow-primary/50 shadow hover:shadow-md transition-shadow",
 				destructive:
-					"bg-destructive text-destructive-foreground hover:bg-destructive/90 shadow-destructive/50 hover:shadow-destructive/50 shadow hover:shadow-md transition-shadow uppercase",
+					"bg-destructive text-destructive-foreground hover:bg-destructive/90 shadow-destructive/50 hover:shadow-destructive/50 shadow hover:shadow-md transition-shadow",
 				"outline-success":
 					"border border-input hover:text-accent-foreground border-success hover:border-success/70 text-success hover:text-success/70",
 				secondary:
-					"bg-secondary text-secondary-foreground hover:bg-secondary/80 shadow-secondary/50 hover:shadow-secondary/50 shadow hover:shadow-md transition-shadow uppercase",
+					"bg-secondary text-secondary-foreground hover:bg-secondary/80 shadow-secondary/50 hover:shadow-secondary/50 shadow hover:shadow-md transition-shadow",
 				ghost:
 					"hover:bg-accent text-accent-foreground hover:text-accent-foreground",
 				"ghost-destructive":
 					"hover:bg-destructive/10 text-destructive hover:text-destructive",
 				link: "text-primary underline-offset-4 hover:underline",
-				info: "bg-info text-info-foreground hover:bg-info/90 shadow-info/50 hover:shadow-info/50 shadow hover:shadow-md transition-shadow uppercase",
+				info: "bg-info text-info-foreground hover:bg-info/90 shadow-info/50 hover:shadow-info/50 shadow hover:shadow-md transition-shadow",
 				success:
-					"bg-success text-success-foreground hover:bg-success/90 shadow-success/50 hover:shadow-success/50 shadow hover:shadow-md transition-shadow uppercase",
+					"bg-success text-success-foreground hover:bg-success/90 shadow-success/50 hover:shadow-success/50 shadow hover:shadow-md transition-shadow",
 			},
 			size: {
 				default: "h-10 px-4 py-2",


### PR DESCRIPTION
Forcing button text to be converted to uppercase may lead to unexpected wording.
The conversion to uppercase should be specified in each value within locale files.
Therefore, in this PR, I have removed the uppercase conversion from the Button component.
Additionally, I searched for any other instances of uppercase, lowercase, or capitalize being used, but found none, so there should be no issues.