### PR TITLE
chore(l10n): [de_DE] update locale and line-break fix for en.

### DIFF
--- a/vrc-get-gui/locales/de.json5
+++ b/vrc-get-gui/locales/de.json5
@@ -382,6 +382,8 @@
     "settings:toast:not unity": "Ungültige Unity-Datei",
     "settings:toast:unity already added": "Ausgewähltes Unity bereits vorhanden",
     "settings:toast:unity added": "Unity erfolgreich hinzugefügt!",
+    "settings:use legacy unity hub loading": "Verwende alte Unity Hub Installationserkennung",
+    "settings:use legacy unity hub loading description": "Die alte Installationserkennung ist möglicherweise zuverlässiger, benötigt aber wesentlich mehr Zeit.<br/>Diese alte Methode wird in Zukunft entfernt, bitte melde Probleme über 'Fehler melden' weiter unten.",
 
     "settings:default unity arguments": "Standard Unity Befehlzeilen Parameter",
     "settings:default unity arguments description": "Diese Befehlzeilen Parameter werden benutzt wenn Unity über ALCOM geöffnet wird.",

--- a/vrc-get-gui/locales/en.json5
+++ b/vrc-get-gui/locales/en.json5
@@ -383,7 +383,7 @@
     "settings:toast:unity already added": "Selected Unity was already added.",
     "settings:toast:unity added": "Added Unity successfully!",
     "settings:use legacy unity hub loading": "Use legacy Unity Hub loading",
-    "settings:use legacy unity hub loading description": "Legacy Unity Hub loading is more reliable to load unity list from Unity Hub than new current method, but legacy method will take much time.\nLegacy method will be removed in future so if there is some problems with new method, please report developer from section below.",
+    "settings:use legacy unity hub loading description": "Legacy Unity Hub loading is more reliable to load unity list from Unity Hub than new current method, but legacy method will take much time.<br/>Legacy method will be removed in future so if there is some problems with new method, please report developer from section below.",
 
     "settings:default unity arguments": "Default Unity Command-line Arguments",
     "settings:default unity arguments description": "Those command-line arguments will be used when opening Unity from ALCOM.",


### PR DESCRIPTION
The englisch template uses \n for a new string instead of <br/>, resulting in that line break being ignored.

Also new strings for german locale.