### PR TITLE
fix(gui): text style for "remove project"

### DIFF
--- a/vrc-get-gui/app/_main/projects/manage/index.tsx
+++ b/vrc-get-gui/app/_main/projects/manage/index.tsx
@@ -728,7 +728,7 @@ function DropdownMenuContentBody({
 			</DropdownMenuItem>
 			<DropdownMenuItem
 				onClick={onRemove}
-				className={"bg-destructive text-destructive-foreground"}
+				className={"text-destructive focus:text-destructive"}
 			>
 				{tc("projects:remove project")}
 			</DropdownMenuItem>


### PR DESCRIPTION
「プロジェクトを削除」の文字スタイルが プロジェクト一覧画面 と プロジェクトの管理画面 で異なっていたため、プロジェクト一覧画面 に合わせて修正しました。
![unknown_2025 03 12-00 59](https://github.com/user-attachments/assets/db9fc83b-a92e-4030-8bd9-40d16aff35d9)
![unknown_2025 03 12-00 59_1](https://github.com/user-attachments/assets/4449b674-4aea-4d70-b4da-1ef0d31f3167)