### PR TITLE
fix: wrong litedb filename

### DIFF
--- a/CHANGELOG-gui.md
+++ b/CHANGELOG-gui.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog].
 ### Added
 
 ### Changed
-- Changed how we read VCC's project information `#1997`
+- Changed how we read VCC's project information `#1997` `#2036`
   - Along with this, building this project no longer needs dotnet SDK to build.
 - Migrated the project to Rust 2024 `#1956`
   - This is internal changes should not cause behavior changes

--- a/vrc-get-vpm/src/environment/litedb.rs
+++ b/vrc-get-vpm/src/environment/litedb.rs
@@ -12,7 +12,7 @@ pub struct VccDatabaseConnection {
     _guard: has_drop::MutexGuard,
 }
 
-static FILE_NAME: &str = "vcc.liteDB";
+static FILE_NAME: &str = "vcc.liteDb";
 
 impl VccDatabaseConnection {
     pub async fn connect(io: &impl EnvironmentIo) -> io::Result<Self> {


### PR DESCRIPTION
ファイル名の大文字小文字が区別されるシステムでは、 d5da94a3 以降のコミットでALCOMの起動時にNo such file or directory (os error 2)というエラーが発生していました。
これは以前のバージョンでvcc.liteDbという名前で作成していたファイルをvcc.liteDBという名前で読み込もうとしていることが原因です。

ファイルが存在しない場合には新しく生成されるべきだとは思いますが、それはlitedb-rs側の責務だと思うのでこのPRでは特に触っていません。
また、このPRがmasterブランチにマージされてもUnityHubから情報を読み込む時などにlitedb-rs側でpanicが発生しますが、こちらも触れていません。