### PR TITLE
chore: remove unnecessary special handling for unity 6 implemented before Unity 6000 release

### DIFF
--- a/vrc-get-vpm/src/version/unity_version.rs
+++ b/vrc-get-vpm/src/version/unity_version.rs
@@ -206,36 +206,11 @@ impl PartialOrd<Self> for UnityVersion {
 impl Ord for UnityVersion {
     fn cmp(&self, other: &Self) -> Ordering {
         // We ignore china increment for comparing version
-        major_ord(self.major(), other.major())
+        (self.major().cmp(&other.major()))
             .then_with(|| self.minor().cmp(&other.minor()))
             .then_with(|| self.revision().cmp(&other.revision()))
             .then_with(|| self.type_().cmp(&other.type_()))
             .then_with(|| self.increment().cmp(&other.increment()))
-    }
-}
-
-// 1 < 2 < 3 < 4 < 5 < years < 6
-fn major_ord(this: u16, other: u16) -> Ordering {
-    let this_year = this >= 2000;
-    let other_year = other >= 2000;
-
-    match (this_year, other_year) {
-        (true, true) => this.cmp(&other),
-        (false, false) => this.cmp(&other),
-        (true, false) => {
-            if other <= 5 {
-                Ordering::Greater
-            } else {
-                Ordering::Less
-            }
-        }
-        (false, true) => {
-            if this <= 5 {
-                Ordering::Less
-            } else {
-                Ordering::Greater
-            }
-        }
     }
 }
 
@@ -392,29 +367,6 @@ mod tests {
         bad!("2019.0");
         bad!("5.6.6");
         bad!("2023.4.6f");
-    }
-
-    #[test]
-    fn ord_major() {
-        macro_rules! test {
-            ($left: literal <  $right: literal) => {
-                assert_eq!(major_ord($left, $right), Ordering::Less);
-            };
-            ($left: literal > $right: literal) => {
-                assert_eq!(major_ord($left, $right), Ordering::Greater);
-            };
-            ($left: literal = $right: literal) => {
-                assert_eq!(major_ord($left, $right), Ordering::Equal);
-            };
-        }
-
-        test!(4 < 5);
-        test!(5 < 2017);
-        test!(2017 < 2023);
-        test!(2023 < 6);
-        test!(6 < 7);
-
-        test!(5 < 6);
     }
 
     #[test]


### PR DESCRIPTION
The logic is not necessary because Unity uses 6000 for unity 6 so we don't have to compare as 5 < 20xx < 6, we just simplty 5 < 20xx < 6000