### PR TITLE
ci: use ubuntu-22.04 for building new ALCOM

### DIFF
--- a/.github/workflows/ci-gui.yml
+++ b/.github/workflows/ci-gui.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         include:
           - triple: x86_64-unknown-linux-gnu
-            on: ubuntu-latest
+            on: ubuntu-22.04
             setup: |
               sudo apt update && sudo apt install -y lld
               ld.lld --version

--- a/.github/workflows/publish-gui.yml
+++ b/.github/workflows/publish-gui.yml
@@ -167,7 +167,7 @@ jobs:
           # note: when you changed paths for tauri updater (which are files with .sig),
           # remember keep in sync with build-updater-json
           - triple: x86_64-unknown-linux-gnu
-            on: ubuntu-latest
+            on: ubuntu-22.04
             setup: |
               sudo apt update && sudo apt install -y lld
               ld.lld --version

--- a/CHANGELOG-gui.md
+++ b/CHANGELOG-gui.md
@@ -43,6 +43,9 @@ The format is based on [Keep a Changelog].
 - Improves launching unity behavior `#2124`
   - On linux, ALCOM will now read exit code, therefore, Unity no longer remains as a defunct process.
   - On macOS, we now launch Unity as a distinct / individual process, therefore several macOS subsystems should treat Unity as Unity instead of Unity as a part of ALCOM.
+- Downgraded glibc requirements for linux images `#2160`
+  - This release will be built on ubuntu 22.04 so glibc 2.35 is new requirements
+  - If you want to use on platforms with older glibc, build yourself or pull request to build on older environments.
 
 ### Deprecated
 


### PR DESCRIPTION
To resolve glibc version problem, I changed ubuntu version used for building .deb and appimage to 22.04, which is oldest supported LTS with webkit2gtk 4.1

Closes #1996
Closes #2145
Related #1914 