### PR TITLE
feat(templates): refine template ID generation and validation

### DIFF
--- a/vrc-get-gui/src/commands/environment/templates.rs
+++ b/vrc-get-gui/src/commands/environment/templates.rs
@@ -123,13 +123,19 @@ pub async fn environment_save_template(
     vpm_packages: Vec<(String, String)>,
     unity_packages: Vec<String>,
 ) -> Result<(), RustError> {
+    // Determine effective id: keep given one or generate new
+    let effective_id = id.clone().unwrap_or_else(|| {
+        format!(
+            "{}{}",
+            "com.anatawa12.vrc-get.user.",
+            uuid::Uuid::new_v4().simple()
+        )
+    });
+    
     let template = AlcomTemplate {
         display_name: name.clone(),
         update_date: Some(chrono::Utc::now()),
-        id: id
-            .as_ref()
-            .take_if(|x| !x.starts_with("com.anatawa12.vrc-get.user."))
-            .cloned(),
+        id: Some(effective_id.clone()),
         base,
         unity_version: Some(VersionRange::from_str(&unity_range).map_err(|x| {
             RustError::unrecoverable(format!("Bad Unity Version Range ({unity_range}): {x}"))

--- a/vrc-get-gui/src/templates.rs
+++ b/vrc-get-gui/src/templates.rs
@@ -190,29 +190,47 @@ pub async fn load_resolve_alcom_templates(
             let alcom = template.alcom_template.as_ref().unwrap();
             let Some(base) = template_by_id.get(&alcom.base) else {
                 // The template will never become available so remove from keys to update
+                log::debug!("Template {}: Base template {} not found.", k, alcom.base);
                 return false;
             };
 
             if !base.available {
                 // The base template is not available yet. Retry later
+                log::debug!("Template {}: Base template {} not available yet.", k, alcom.base);
                 return true;
             }
 
-            // The base template is available! update this template based on the base template
+            let mut unity_versions = Vec::new(); // Start with empty
 
-            let unity_versions = if let Some(unity_filter) = &alcom.unity_version {
-                base.unity_versions
-                    .iter()
-                    .copied()
-                    .filter(|x| unity_filter.matches(&x.as_semver()))
-                    .collect()
+            if let Some(unity_filter) = &alcom.unity_version {
+                let unity_filter_str = unity_filter.to_string();
+                match vrc_get_vpm::version::UnityVersion::parse(&unity_filter_str) {
+                    Some(specific_version) => {
+                        log::debug!("  Parsed as specific version: {}", specific_version);
+                        if base.unity_versions.contains(&specific_version) {
+                            log::debug!("   Specific version is compatible with base.");
+                            unity_versions.push(specific_version); // Use only this specific version
+                        } else {
+                            log::warn!("   Specific version {} is NOT compatible with base versions: {:?}", specific_version, base.unity_versions);
+                        }
+                    }
+                    None => {
+                        unity_versions = base.unity_versions
+                            .iter()
+                            .copied()
+                            .filter(|x| unity_filter.matches(&x.as_semver()))
+                            .collect();
+                    }
+                }
             } else {
-                base.unity_versions.clone()
-            };
+                unity_versions = base.unity_versions.clone()
+            }
 
             let template_mut = &mut template_by_id[k];
             template_mut.unity_versions = unity_versions;
-            template_mut.available = true;
+            // Mark as available only if we found at least one compatible Unity version.
+            template_mut.available = !template_mut.unity_versions.is_empty();
+            log::debug!(" Template {} marked as available: {}", k, template_mut.available);
 
             updated = true;
 
@@ -472,22 +490,39 @@ pub async fn create_project(
                     .alcom_template
                     .as_ref()
                     .expect("no .alcomtemplate info");
+                log::debug!("Resolving custom template: {} based on {}", id, template.base);
+
                 let mut resolved = resolve_template(templates, &template.base, unity_version)?;
 
+                // Merge VPM dependencies
                 for (pkg_id, range) in &template.vpm_dependencies {
                     match resolved.packages.entry(pkg_id.clone()) {
                         Entry::Occupied(mut e) => {
-                            let range = range.intersect(e.get());
-                            e.insert(range);
+                            log::debug!(
+                                "Merging existing dependency: {} (Base: {}, Custom: {})",
+                                pkg_id,
+                                e.get(),
+                                range
+                            );
+                            let intersected_range = range.intersect(e.get());
+                            e.insert(intersected_range);
                         }
                         Entry::Vacant(e) => {
+                            log::debug!("Adding new dependency: {} {}", pkg_id, range);
                             e.insert(range.clone());
                         }
                     }
                 }
 
+                // Merge Unity packages
                 (resolved.unity_packages).extend(template.unity_packages.iter().cloned());
 
+                log::debug!("Final resolved packages for {}: {:?}", id, resolved.packages);
+                log::debug!(
+                    "Final resolved unityPackages for {}: {:?}",
+                    id,
+                    resolved.unity_packages
+                );
                 Some(resolved)
             }
         }

--- a/vrc-get-gui/src/templates.rs
+++ b/vrc-get-gui/src/templates.rs
@@ -190,47 +190,29 @@ pub async fn load_resolve_alcom_templates(
             let alcom = template.alcom_template.as_ref().unwrap();
             let Some(base) = template_by_id.get(&alcom.base) else {
                 // The template will never become available so remove from keys to update
-                log::debug!("Template {}: Base template {} not found.", k, alcom.base);
                 return false;
             };
 
             if !base.available {
                 // The base template is not available yet. Retry later
-                log::debug!("Template {}: Base template {} not available yet.", k, alcom.base);
                 return true;
             }
 
-            let mut unity_versions = Vec::new(); // Start with empty
+            // The base template is available! update this template based on the base template
 
-            if let Some(unity_filter) = &alcom.unity_version {
-                let unity_filter_str = unity_filter.to_string();
-                match vrc_get_vpm::version::UnityVersion::parse(&unity_filter_str) {
-                    Some(specific_version) => {
-                        log::debug!("  Parsed as specific version: {}", specific_version);
-                        if base.unity_versions.contains(&specific_version) {
-                            log::debug!("   Specific version is compatible with base.");
-                            unity_versions.push(specific_version); // Use only this specific version
-                        } else {
-                            log::warn!("   Specific version {} is NOT compatible with base versions: {:?}", specific_version, base.unity_versions);
-                        }
-                    }
-                    None => {
-                        unity_versions = base.unity_versions
-                            .iter()
-                            .copied()
-                            .filter(|x| unity_filter.matches(&x.as_semver()))
-                            .collect();
-                    }
-                }
+            let unity_versions = if let Some(unity_filter) = &alcom.unity_version {
+                base.unity_versions
+                    .iter()
+                    .copied()
+                    .filter(|x| unity_filter.matches(&x.as_semver()))
+                    .collect()
             } else {
-                unity_versions = base.unity_versions.clone()
-            }
+                base.unity_versions.clone()
+            };
 
             let template_mut = &mut template_by_id[k];
             template_mut.unity_versions = unity_versions;
-            // Mark as available only if we found at least one compatible Unity version.
-            template_mut.available = !template_mut.unity_versions.is_empty();
-            log::debug!(" Template {} marked as available: {}", k, template_mut.available);
+            template_mut.available = true;
 
             updated = true;
 
@@ -490,39 +472,22 @@ pub async fn create_project(
                     .alcom_template
                     .as_ref()
                     .expect("no .alcomtemplate info");
-                log::debug!("Resolving custom template: {} based on {}", id, template.base);
-
                 let mut resolved = resolve_template(templates, &template.base, unity_version)?;
 
-                // Merge VPM dependencies
                 for (pkg_id, range) in &template.vpm_dependencies {
                     match resolved.packages.entry(pkg_id.clone()) {
                         Entry::Occupied(mut e) => {
-                            log::debug!(
-                                "Merging existing dependency: {} (Base: {}, Custom: {})",
-                                pkg_id,
-                                e.get(),
-                                range
-                            );
-                            let intersected_range = range.intersect(e.get());
-                            e.insert(intersected_range);
+                            let range = range.intersect(e.get());
+                            e.insert(range);
                         }
                         Entry::Vacant(e) => {
-                            log::debug!("Adding new dependency: {} {}", pkg_id, range);
                             e.insert(range.clone());
                         }
                     }
                 }
 
-                // Merge Unity packages
                 (resolved.unity_packages).extend(template.unity_packages.iter().cloned());
 
-                log::debug!("Final resolved packages for {}: {:?}", id, resolved.packages);
-                log::debug!(
-                    "Final resolved unityPackages for {}: {:?}",
-                    id,
-                    resolved.unity_packages
-                );
                 Some(resolved)
             }
         }


### PR DESCRIPTION
Improves the handling of template IDs in the backend:
- When saving a new template, generates a unique ID within the
  'com.anatawa12.vrc-get.user.' namespace if no ID is provided.
- Enhances ID validation to allow '.user.' and '.vcc.' sub-namespaces
  under 'com.anatawa12.vrc-get.*' while reserving other sub-namespaces.
- Prevents user-defined templates ('.user.*') from being used as
  base templates.

Also fixes a bug with invalid template ID on edit template