### PR TITLE
chore(deps): remove postcss from direct dependencies

### DIFF
--- a/vrc-get-gui/package-lock.json
+++ b/vrc-get-gui/package-lock.json
@@ -46,7 +46,6 @@
 				"@types/react-dom": "19.1.5",
 				"@vitejs/plugin-react-swc": "^3.8.1",
 				"json5": "^2",
-				"postcss": "^8",
 				"sharp-cli": "^5.1.0",
 				"svgo": "^3.3.2",
 				"tw-animate-css": "^1.3.0",

--- a/vrc-get-gui/package.json
+++ b/vrc-get-gui/package.json
@@ -52,7 +52,6 @@
 		"@types/react-dom": "19.1.5",
 		"@vitejs/plugin-react-swc": "^3.8.1",
 		"json5": "^2",
-		"postcss": "^8",
 		"sharp-cli": "^5.1.0",
 		"svgo": "^3.3.2",
 		"tw-animate-css": "^1.3.0",


### PR DESCRIPTION
Please note that postcss is needed by vite so no lock dependencies are changed