### PR TITLE
fix: a reorderable list may become empty even if allowEmpty = false

### DIFF
--- a/vrc-get-gui/app/_main/packages/templates/index.tsx
+++ b/vrc-get-gui/app/_main/packages/templates/index.tsx
@@ -453,7 +453,7 @@ function TemplateEditor({
 		defaultValue: { name: "", range: "" },
 		defaultArray:
 			template == null
-				? [{ name: "", range: "" }]
+				? []
 				: Object.entries(template.vpm_dependencies).map(([name, range]) => ({
 						name,
 						range,

--- a/vrc-get-gui/components/ReorderableList.tsx
+++ b/vrc-get-gui/components/ReorderableList.tsx
@@ -74,11 +74,11 @@ export function useReorderableList<T extends NonFunction>({
 }): ReorderableListContext<T> {
 	const [backedList, setBackedList] = useState<ReordeableListValue<T>[]>(() => {
 		if (defaultArray != null) {
-			if (typeof defaultArray === "function") {
-				return defaultArray().map(makeValue);
-			} else {
-				return defaultArray.map(makeValue);
-			}
+			let defaultSpecified =
+				typeof defaultArray === "function" ? defaultArray() : defaultArray;
+			if (!allowEmpty && defaultSpecified.length === 0)
+				defaultSpecified = [defaultValue];
+			return defaultSpecified.map(makeValue);
 		} else {
 			return allowEmpty ? [] : [makeValue(defaultValue)];
 		}


### PR DESCRIPTION
Fix #2264