### PR TITLE
Crash on creating project

### DIFF
--- a/CHANGELOG-gui.md
+++ b/CHANGELOG-gui.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog].
 
 ### Fixed
 - Unity can be duplicated `#2321`
+- Crash on creating a new project on Windows `#2326`
 
 ### Security
 

--- a/vrc-get-gui/app/_main/projects/-create-project.tsx
+++ b/vrc-get-gui/app/_main/projects/-create-project.tsx
@@ -70,7 +70,6 @@ export async function createProject() {
 	);
 	dialog.close();
 	toastSuccess(tt("projects:toast:project created"));
-	close?.();
 	await queryClient.invalidateQueries({
 		queryKey: ["environmentProjects"],
 	});

--- a/vrc-get-gui/biome.jsonc
+++ b/vrc-get-gui/biome.jsonc
@@ -24,6 +24,12 @@
 					// In my opinion, '!.' => '?.' is not reasonable for all cases, so I disabled automatic fix.
 					"fix": "none",
 					"level": "error"
+				},
+				"noRestrictedGlobals": {
+					"level": "error",
+					"options": {
+						"deniedGlobals": ["close"]
+					}
 				}
 			},
 			"suspicious": {


### PR DESCRIPTION
Closes #2325

The webview crashes because calling `window.close` broke wry's webview, but calling `window.close` itself is a problem in ALCOM so this fixes the call.

The issue for breaking window on window.close is tauri-apps/tauri#13331