### PR TITLE
Add fr translations 1.1.3

### DIFF
--- a/vrc-get-gui/locales/fr.json5
+++ b/vrc-get-gui/locales/fr.json5
@@ -373,7 +373,7 @@
     'templates:category:vcc': 'VCC',
     'templates:create template': 'Créer un modèle',
     'templates:dialog:any unity specified version': 'Toutes les versions {{version}} de Unity',
-    'templates:dialog:any version': 'Toues les versions de Unity',
+    'templates:dialog:any version': 'Toutes les versions de Unity',
     'templates:dialog:base template': 'Modèle de base',
     'templates:dialog:button:override templates': 'Mettre a jour {{count}} modèle(s)',
     'templates:dialog:confirm remove template': 'Etes vous sur de vouloir supprimer le modèle {{displayName}} ?',


### PR DESCRIPTION
Added missing translations, but for the unity version, i feel it takes lots of space. Is that an issue ?

<img width="301" height="264" alt="image" src="https://github.com/user-attachments/assets/8d0d719d-5769-4c18-a006-12857dfa424d" />
