### PR TITLE
fix: muted-foreground color definition in css

### DIFF
--- a/vrc-get-gui/app/globals.css
+++ b/vrc-get-gui/app/globals.css
@@ -99,7 +99,7 @@
 	--secondary: hsl(240 4.8% 95.9%);
 	--secondary-foreground: hsl(240 5.9% 10%);
 	--muted: hsl(240 4.8% 95.9%);
-	--muted-foreground: hsl(240 3.8% 46.1%);
+	--muted-foreground: oklch(0.556 0 0);
 	--accent: hsl(240 4.8% 95.9%);
 	--accent-foreground: hsl(240 5.9% 30%);
 	--info: hsl(207 90% 54%);
@@ -135,7 +135,7 @@
 	--secondary: var(--secondary-bg);
 	--secondary-foreground: var(--fg-color);
 	--muted: var(--secondary-bg);
-	--muted-foreground: 240 5% 74%;
+	--muted-foreground: oklch(0.708 0 0);
 	--accent: var(--secondary-bg);
 	--accent-foreground: var(--fg-color);
 	--info: hsl(207 90% 54%);
@@ -171,7 +171,7 @@
 		--secondary: var(--secondary-bg);
 		--secondary-foreground: var(--fg-color);
 		--muted: var(--secondary-bg);
-		--muted-foreground: 240 5% 74%;
+		--muted-foreground: oklch(0.708 0 0);
 		--accent: var(--secondary-bg);
 		--accent-foreground: var(--fg-color);
 		--info: hsl(207 90% 54%);


### PR DESCRIPTION
- `muted-foreground`の色指定が誤っていて反映されていなかったため修正
- primaryとmuted-foregroundの差が少なかったためshadcnのデフォルトの色に変更

<img width="232" height="62" alt="image" src="https://github.com/user-attachments/assets/a6096f64-7c6f-43e5-bdba-1cb12e535fac" />
<img width="219" height="78" alt="image" src="https://github.com/user-attachments/assets/53cc7a6e-13c2-487f-a441-850c745cf8b6" />

<img width="228" height="66" alt="image" src="https://github.com/user-attachments/assets/790961ba-2f31-4d8c-adad-00f2b17c8d70" />
<img width="236" height="92" alt="image" src="https://github.com/user-attachments/assets/2e5443b8-d8ae-436f-9103-583875a22eb7" />
