### PR TITLE
fix: replace some DialogDescription with div in dialog components

### DIFF
--- a/CHANGELOG-gui.md
+++ b/CHANGELOG-gui.md
@@ -17,7 +17,8 @@ The format is based on [Keep a Changelog].
 
 ### Fixed
 
-- Fix muted-foreground color [`#2516`](https://github.com/vrc-get/vrc-get/pull/2516)
+- Fix muted-foreground color [`#2516`](https://github.com/vrc-get/vrc-get/pull/2516) [`#2517`](https://github.com/vrc-get/vrc-get/pull/2517)
+  - Remove `DialogDescription` not in `DialogHeader` to fix text color
 
 ### Security
 

--- a/vrc-get-gui/app/_main/packages/repositories/-use-add-repository.tsx
+++ b/vrc-get-gui/app/_main/packages/repositories/-use-add-repository.tsx
@@ -6,7 +6,7 @@ import {
 	useReorderableList,
 } from "@/components/ReorderableList";
 import { Button } from "@/components/ui/button";
-import { DialogDescription, DialogFooter } from "@/components/ui/dialog";
+import { DialogFooter } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { assertNever } from "@/lib/assert-never";
 import type {
@@ -156,7 +156,7 @@ function EnteringRepositoryInfo({
 
 	return (
 		<>
-			<DialogDescription>
+			<div>
 				<p className={"font-normal"}>
 					{tc("vpm repositories:dialog:enter repository info")}
 				</p>
@@ -242,7 +242,7 @@ function EnteringRepositoryInfo({
 						{tc("vpm repositories:hint:duplicate headers")}
 					</p>
 				)}
-			</DialogDescription>
+			</div>
 			<DialogFooter>
 				<Button onClick={() => dialog.close(null)}>
 					{tc("general:button:cancel")}
@@ -262,9 +262,9 @@ function EnteringRepositoryInfo({
 function LoadingRepository({ cancel }: { cancel: () => void }) {
 	return (
 		<>
-			<DialogDescription>
+			<div>
 				<p>{tc("vpm repositories:dialog:downloading...")}</p>
-			</DialogDescription>
+			</div>
 			<DialogFooter>
 				<Button onClick={cancel}>{tc("general:button:cancel")}</Button>
 			</DialogFooter>
@@ -303,10 +303,10 @@ function Duplicated({
 
 	return (
 		<>
-			<DialogDescription>
+			<div>
 				<p>{tc("vpm repositories:dialog:already added")}</p>
 				<p>{message}</p>
-			</DialogDescription>
+			</div>
 			<DialogFooter>
 				<Button onClick={() => dialog.close()}>
 					{tc("general:button:ok")}
@@ -328,7 +328,7 @@ function Confirming({
 	return (
 		<>
 			{/* TODO: use ScrollArea (I failed to use it inside dialog) */}
-			<DialogDescription className={"max-h-[50vh] overflow-y-auto font-normal"}>
+			<div className={"max-h-[50vh] overflow-y-auto font-normal"}>
 				<p className={"font-normal"}>
 					{tc("vpm repositories:dialog:name", { name: repo.display_name })}
 				</p>
@@ -357,7 +357,7 @@ function Confirming({
 						<li key={info.name}>{info.display_name ?? info.name}</li>
 					))}
 				</ul>
-			</DialogDescription>
+			</div>
 			<DialogFooter>
 				<Button onClick={() => dialog.close(false)}>
 					{tc("general:button:cancel")}

--- a/vrc-get-gui/app/_main/packages/repositories/-use-import-repositories.tsx
+++ b/vrc-get-gui/app/_main/packages/repositories/-use-import-repositories.tsx
@@ -8,7 +8,7 @@ import {
 	AccordionTrigger,
 } from "@/components/ui/accordion";
 import { Button } from "@/components/ui/button";
-import { DialogDescription, DialogFooter } from "@/components/ui/dialog";
+import { DialogFooter } from "@/components/ui/dialog";
 import { Progress } from "@/components/ui/progress";
 import { assertNever } from "@/lib/assert-never";
 import type {
@@ -93,7 +93,7 @@ function ConfirmingRepositoryList({
 	return (
 		<>
 			{/* TODO: use ScrollArea (I failed to use it inside dialog) */}
-			<DialogDescription className={"max-h-[50vh] overflow-y-auto font-normal"}>
+			<div className={"max-h-[50vh] overflow-y-auto font-normal"}>
 				<p className={"font-normal whitespace-normal"}>
 					{tc("vpm repositories:dialog:confirm repository list")}
 				</p>
@@ -119,7 +119,7 @@ function ConfirmingRepositoryList({
 						</ul>
 					</>
 				)}
-			</DialogDescription>
+			</div>
 			<DialogFooter className={"gap-2"}>
 				<Button onClick={() => dialog.close(null)}>
 					{tc("general:button:cancel")}
@@ -159,7 +159,7 @@ function LoadingRepositories({
 
 	return (
 		<>
-			<DialogDescription>
+			<div>
 				<p>{tc("vpm repositories:dialog:downloading repositories...")}</p>
 				<Progress value={downloaded} max={totalCount} />
 				<div className={"text-center"}>
@@ -168,7 +168,7 @@ function LoadingRepositories({
 						totalCount,
 					})}
 				</div>
-			</DialogDescription>
+			</div>
 			<DialogFooter>
 				<Button onClick={() => cancelRef.current?.()}>
 					{tc("general:button:cancel")}
@@ -196,7 +196,7 @@ function ConfirmingPackages({
 	return (
 		<>
 			{/* TODO: use ScrollArea (I failed to use it inside dialog) */}
-			<DialogDescription className={"font-normal"}>
+			<div className={"font-normal"}>
 				<p className={"whitespace-normal"}>
 					{tc("vpm repositories:dialog:confirm packages list")}
 				</p>
@@ -249,7 +249,7 @@ function ConfirmingPackages({
 						);
 					})}
 				</Accordion>
-			</DialogDescription>
+			</div>
 			<DialogFooter>
 				<Button onClick={() => dialog.close(null)}>
 					{tc("general:button:cancel")}
@@ -264,8 +264,8 @@ function ConfirmingPackages({
 
 function AddingRepositories() {
 	return (
-		<DialogDescription>
+		<div>
 			<p>{tc("vpm repositories:dialog:adding repositories...")}</p>
-		</DialogDescription>
+		</div>
 	);
 }

--- a/vrc-get-gui/app/_main/packages/repositories/index.tsx
+++ b/vrc-get-gui/app/_main/packages/repositories/index.tsx
@@ -14,7 +14,6 @@ import { ScrollableCardTable } from "@/components/ScrollableCardTable";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
-	DialogDescription,
 	DialogFooter,
 	DialogTitle,
 } from "@/components/ui/dialog";
@@ -359,13 +358,13 @@ function RemoveRepositoryDialog({
 	return (
 		<>
 			<DialogTitle>{tc("vpm repositories:remove repository")}</DialogTitle>
-			<DialogDescription>
+			<div>
 				<p className={"whitespace-normal font-normal"}>
 					{tc("vpm repositories:dialog:confirm remove description", {
 						name: displayName,
 					})}
 				</p>
-			</DialogDescription>
+			</div>
 			<DialogFooter>
 				<Button onClick={() => dialog.close()}>
 					{tc("general:button:cancel")}

--- a/vrc-get-gui/app/_main/packages/repositories/index.tsx
+++ b/vrc-get-gui/app/_main/packages/repositories/index.tsx
@@ -13,10 +13,7 @@ import { HNavBar, VStack } from "@/components/layout";
 import { ScrollableCardTable } from "@/components/ScrollableCardTable";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import {
-	DialogFooter,
-	DialogTitle,
-} from "@/components/ui/dialog";
+import { DialogFooter, DialogTitle } from "@/components/ui/dialog";
 import {
 	DropdownMenu,
 	DropdownMenuContent,

--- a/vrc-get-gui/app/_main/packages/templates/index.tsx
+++ b/vrc-get-gui/app/_main/packages/templates/index.tsx
@@ -26,7 +26,6 @@ import {
 } from "@/components/ui/autocomplete";
 import { Button } from "@/components/ui/button";
 import {
-	DialogDescription,
 	DialogFooter,
 	DialogTitle,
 } from "@/components/ui/dialog";
@@ -385,9 +384,9 @@ function RemoveTemplateConfirmDialog({
 	return (
 		<>
 			<DialogTitle>{tc("templates:dialog:remove template")}</DialogTitle>
-			<DialogDescription>
+			<div>
 				{tc("templates:dialog:confirm remove template", { displayName })}
-			</DialogDescription>
+			</div>
 			<DialogFooter>
 				<Button onClick={() => dialog.close(false)}>
 					{tc("general:button:cancel")}
@@ -800,173 +799,171 @@ function TemplateEditor({
 					? tc("templates:dialog:edit template")
 					: tc("templates:dialog:create template")}
 			</DialogTitle>
-			<DialogDescription asChild>
-				<div className={"flex flex-col gap-4 shrink min-h-0"}>
-					<section>
-						<h3 className={"font-bold w-full text-center content-center"}>
-							{tc("templates:dialog:general information")}
-						</h3>
-						<table
-							className={"grid grid-cols-[min-content_1fr] gap-x-4 gap-y-1"}
-						>
-							<tbody className={"contents"}>
-								<tr className={"contents"}>
-									<th className={"content-center text-start whitespace-nowrap"}>
-										{tc("general:name")}:
-									</th>
-									<td className={"flex"}>
-										<Input
-											className={cn(
-												"grow",
-												name.length === 0 &&
-													"border-destructive ring-destructive text-destructive",
-											)}
-											value={name}
-											onChange={(e) => setName(e.target.value)}
-											placeholder={"Your New Template"}
-										/>
-									</td>
-								</tr>
-								<tr className={"contents"}>
-									<th className={"content-center text-start whitespace-nowrap"}>
-										{tc("templates:dialog:base template")}:
-									</th>
-									<td className={"flex"}>
-										<TemplateSelect
-											value={baseTemplate}
-											onValueChange={setBaseTemplate}
-											templates={templates}
-											favoriteTemplates={favoriteTemplates}
-											className={"grow"}
-											excludeNoIdTemplates
-										/>
-									</td>
-								</tr>
-								<tr className={"contents"}>
-									<th className={"content-center text-start whitespace-nowrap"}>
-										{tc("templates:dialog:unity version")}:
-									</th>
-									<td className={"flex"}>
-										<Autocomplete
-											className={cn(
-												"grow",
-												unityRange.match(unityRangeRegex) ||
-													"border-destructive ring-destructive text-destructive",
-											)}
-											value={unityRange}
-											onChange={(value) => setUnityRange(value)}
-											options={unityCandidates}
-										/>
-									</td>
-								</tr>
+			<div className={"flex flex-col gap-4 shrink min-h-0"}>
+				<section>
+					<h3 className={"font-bold w-full text-center content-center"}>
+						{tc("templates:dialog:general information")}
+					</h3>
+					<table
+						className={"grid grid-cols-[min-content_1fr] gap-x-4 gap-y-1"}
+					>
+						<tbody className={"contents"}>
+						<tr className={"contents"}>
+							<th className={"content-center text-start whitespace-nowrap"}>
+								{tc("general:name")}:
+							</th>
+							<td className={"flex"}>
+								<Input
+									className={cn(
+										"grow",
+										name.length === 0 &&
+										"border-destructive ring-destructive text-destructive",
+									)}
+									value={name}
+									onChange={(e) => setName(e.target.value)}
+									placeholder={"Your New Template"}
+								/>
+							</td>
+						</tr>
+						<tr className={"contents"}>
+							<th className={"content-center text-start whitespace-nowrap"}>
+								{tc("templates:dialog:base template")}:
+							</th>
+							<td className={"flex"}>
+								<TemplateSelect
+									value={baseTemplate}
+									onValueChange={setBaseTemplate}
+									templates={templates}
+									favoriteTemplates={favoriteTemplates}
+									className={"grow"}
+									excludeNoIdTemplates
+								/>
+							</td>
+						</tr>
+						<tr className={"contents"}>
+							<th className={"content-center text-start whitespace-nowrap"}>
+								{tc("templates:dialog:unity version")}:
+							</th>
+							<td className={"flex"}>
+								<Autocomplete
+									className={cn(
+										"grow",
+										unityRange.match(unityRangeRegex) ||
+										"border-destructive ring-destructive text-destructive",
+									)}
+									value={unityRange}
+									onChange={(value) => setUnityRange(value)}
+									options={unityCandidates}
+								/>
+							</td>
+						</tr>
+						</tbody>
+					</table>
+				</section>
+				<section className={"shrink overflow-hidden flex flex-col"}>
+					<h3 className={"font-bold w-full text-center content-center"}>
+						{tc("general:packages")}
+					</h3>
+					<div className={"w-full max-h-[30vh] overflow-y-auto shrink"}>
+						<table className={"w-full"}>
+							<thead>
+							<tr>
+								<th className={"sticky top-0 z-10 bg-background"}>
+									{tc("general:name")}
+								</th>
+								<th className={"sticky top-0 z-10 bg-background"}>
+									{tc("general:version")}
+								</th>
+								<th className={"sticky top-0 z-10 bg-background"} />
+							</tr>
+							</thead>
+							<tbody>
+							<ReorderableList
+								context={packagesListContext}
+								renderItem={(value, id) => (
+									<>
+										<td>
+											<div className={"flex"}>
+												<Autocomplete
+													value={value.name}
+													className={"grow"}
+													options={packageCandidates}
+													onChange={(value) =>
+														packagesListContext.update(id, (old) => ({
+															...old,
+															name: value,
+														}))
+													}
+												/>
+											</div>
+										</td>
+										<td>
+											<div className={"flex"}>
+												<Autocomplete
+													value={value.range}
+													className={cn(
+														"grow",
+														validVersion(value) ||
+														"border-destructive ring-destructive text-destructive",
+													)}
+													options={
+														versionCandidatePerPackage.get(value.name) ?? []
+													}
+													onChange={(value) =>
+														packagesListContext.update(id, (old) => ({
+															...old,
+															range: value,
+														}))
+													}
+												/>
+											</div>
+										</td>
+									</>
+								)}
+							/>
 							</tbody>
 						</table>
-					</section>
-					<section className={"shrink overflow-hidden flex flex-col"}>
+					</div>
+				</section>
+				<section className={"shrink overflow-hidden flex flex-col"}>
+					<Overlay>
 						<h3 className={"font-bold w-full text-center content-center"}>
-							{tc("general:packages")}
+							{tc("templates:dialog:unitypackages")}
 						</h3>
-						<div className={"w-full max-h-[30vh] overflow-y-auto shrink"}>
-							<table className={"w-full"}>
-								<thead>
-									<tr>
-										<th className={"sticky top-0 z-10 bg-background"}>
-											{tc("general:name")}
-										</th>
-										<th className={"sticky top-0 z-10 bg-background"}>
-											{tc("general:version")}
-										</th>
-										<th className={"sticky top-0 z-10 bg-background"} />
-									</tr>
-								</thead>
-								<tbody>
-									<ReorderableList
-										context={packagesListContext}
-										renderItem={(value, id) => (
-											<>
-												<td>
-													<div className={"flex"}>
-														<Autocomplete
-															value={value.name}
-															className={"grow"}
-															options={packageCandidates}
-															onChange={(value) =>
-																packagesListContext.update(id, (old) => ({
-																	...old,
-																	name: value,
-																}))
-															}
-														/>
-													</div>
-												</td>
-												<td>
-													<div className={"flex"}>
-														<Autocomplete
-															value={value.range}
-															className={cn(
-																"grow",
-																validVersion(value) ||
-																	"border-destructive ring-destructive text-destructive",
-															)}
-															options={
-																versionCandidatePerPackage.get(value.name) ?? []
-															}
-															onChange={(value) =>
-																packagesListContext.update(id, (old) => ({
-																	...old,
-																	range: value,
-																}))
-															}
-														/>
-													</div>
-												</td>
-											</>
-										)}
-									/>
-								</tbody>
-							</table>
+						<div className={"text-right mb-2"}>
+							<Button onClick={addUnityPackages}>
+								{tc("general:button:add")}
+							</Button>
 						</div>
-					</section>
-					<section className={"shrink overflow-hidden flex flex-col"}>
-						<Overlay>
-							<h3 className={"font-bold w-full text-center content-center"}>
-								{tc("templates:dialog:unitypackages")}
-							</h3>
-							<div className={"text-right mb-2"}>
-								<Button onClick={addUnityPackages}>
-									{tc("general:button:add")}
-								</Button>
-							</div>
-						</Overlay>
-						<div className={"w-full max-h-[30vh] overflow-y-auto shrink"}>
-							<table className={"w-full"}>
-								<tbody>
-									<ReorderableList
-										context={unityPackagesListContext}
-										ifEmpty={() => (
-											<td className={"text-center"}>
-												{tc("templates:dialog:no unitypackages")}
-											</td>
-										)}
-										renderItem={(value) => (
-											<td>
-												<div className={"flex"}>
-													<Input
-														type={"text"}
-														value={value}
-														className={"grow"}
-														disabled
-													/>
-												</div>
-											</td>
-										)}
-									/>
-								</tbody>
-							</table>
-						</div>
-					</section>
-				</div>
-			</DialogDescription>
+					</Overlay>
+					<div className={"w-full max-h-[30vh] overflow-y-auto shrink"}>
+						<table className={"w-full"}>
+							<tbody>
+							<ReorderableList
+								context={unityPackagesListContext}
+								ifEmpty={() => (
+									<td className={"text-center"}>
+										{tc("templates:dialog:no unitypackages")}
+									</td>
+								)}
+								renderItem={(value) => (
+									<td>
+										<div className={"flex"}>
+											<Input
+												type={"text"}
+												value={value}
+												className={"grow"}
+												disabled
+											/>
+										</div>
+									</td>
+								)}
+							/>
+							</tbody>
+						</table>
+					</div>
+				</section>
+			</div>
 			<DialogFooter className={"mt-2"}>
 				<Button onClick={() => dialog.close(false)}>
 					{tc("general:button:cancel")}

--- a/vrc-get-gui/app/_main/packages/templates/index.tsx
+++ b/vrc-get-gui/app/_main/packages/templates/index.tsx
@@ -25,10 +25,7 @@ import {
 	Autocomplete,
 } from "@/components/ui/autocomplete";
 import { Button } from "@/components/ui/button";
-import {
-	DialogFooter,
-	DialogTitle,
-} from "@/components/ui/dialog";
+import { DialogFooter, DialogTitle } from "@/components/ui/dialog";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -804,59 +801,57 @@ function TemplateEditor({
 					<h3 className={"font-bold w-full text-center content-center"}>
 						{tc("templates:dialog:general information")}
 					</h3>
-					<table
-						className={"grid grid-cols-[min-content_1fr] gap-x-4 gap-y-1"}
-					>
+					<table className={"grid grid-cols-[min-content_1fr] gap-x-4 gap-y-1"}>
 						<tbody className={"contents"}>
-						<tr className={"contents"}>
-							<th className={"content-center text-start whitespace-nowrap"}>
-								{tc("general:name")}:
-							</th>
-							<td className={"flex"}>
-								<Input
-									className={cn(
-										"grow",
-										name.length === 0 &&
-										"border-destructive ring-destructive text-destructive",
-									)}
-									value={name}
-									onChange={(e) => setName(e.target.value)}
-									placeholder={"Your New Template"}
-								/>
-							</td>
-						</tr>
-						<tr className={"contents"}>
-							<th className={"content-center text-start whitespace-nowrap"}>
-								{tc("templates:dialog:base template")}:
-							</th>
-							<td className={"flex"}>
-								<TemplateSelect
-									value={baseTemplate}
-									onValueChange={setBaseTemplate}
-									templates={templates}
-									favoriteTemplates={favoriteTemplates}
-									className={"grow"}
-									excludeNoIdTemplates
-								/>
-							</td>
-						</tr>
-						<tr className={"contents"}>
-							<th className={"content-center text-start whitespace-nowrap"}>
-								{tc("templates:dialog:unity version")}:
-							</th>
-							<td className={"flex"}>
-								<Autocomplete
-									className={cn(
-										"grow",
-										unityRange.match(unityRangeRegex) ||
-										"border-destructive ring-destructive text-destructive",
-									)}
-									value={unityRange}
-									onChange={(value) => setUnityRange(value)}
-									options={unityCandidates}
-								/>
-							</td>
-						</tr>
+							<tr className={"contents"}>
+								<th className={"content-center text-start whitespace-nowrap"}>
+									{tc("general:name")}:
+								</th>
+								<td className={"flex"}>
+									<Input
+										className={cn(
+											"grow",
+											name.length === 0 &&
+												"border-destructive ring-destructive text-destructive",
+										)}
+										value={name}
+										onChange={(e) => setName(e.target.value)}
+										placeholder={"Your New Template"}
+									/>
+								</td>
+							</tr>
+							<tr className={"contents"}>
+								<th className={"content-center text-start whitespace-nowrap"}>
+									{tc("templates:dialog:base template")}:
+								</th>
+								<td className={"flex"}>
+									<TemplateSelect
+										value={baseTemplate}
+										onValueChange={setBaseTemplate}
+										templates={templates}
+										favoriteTemplates={favoriteTemplates}
+										className={"grow"}
+										excludeNoIdTemplates
+									/>
+								</td>
+							</tr>
+							<tr className={"contents"}>
+								<th className={"content-center text-start whitespace-nowrap"}>
+									{tc("templates:dialog:unity version")}:
+								</th>
+								<td className={"flex"}>
+									<Autocomplete
+										className={cn(
+											"grow",
+											unityRange.match(unityRangeRegex) ||
+												"border-destructive ring-destructive text-destructive",
+										)}
+										value={unityRange}
+										onChange={(value) => setUnityRange(value)}
+										options={unityCandidates}
+									/>
+								</td>
+							</tr>
 						</tbody>
 					</table>
 				</section>
@@ -867,60 +862,60 @@ function TemplateEditor({
 					<div className={"w-full max-h-[30vh] overflow-y-auto shrink"}>
 						<table className={"w-full"}>
 							<thead>
-							<tr>
-								<th className={"sticky top-0 z-10 bg-background"}>
-									{tc("general:name")}
-								</th>
-								<th className={"sticky top-0 z-10 bg-background"}>
-									{tc("general:version")}
-								</th>
-								<th className={"sticky top-0 z-10 bg-background"} />
-							</tr>
+								<tr>
+									<th className={"sticky top-0 z-10 bg-background"}>
+										{tc("general:name")}
+									</th>
+									<th className={"sticky top-0 z-10 bg-background"}>
+										{tc("general:version")}
+									</th>
+									<th className={"sticky top-0 z-10 bg-background"} />
+								</tr>
 							</thead>
 							<tbody>
-							<ReorderableList
-								context={packagesListContext}
-								renderItem={(value, id) => (
-									<>
-										<td>
-											<div className={"flex"}>
-												<Autocomplete
-													value={value.name}
-													className={"grow"}
-													options={packageCandidates}
-													onChange={(value) =>
-														packagesListContext.update(id, (old) => ({
-															...old,
-															name: value,
-														}))
-													}
-												/>
-											</div>
-										</td>
-										<td>
-											<div className={"flex"}>
-												<Autocomplete
-													value={value.range}
-													className={cn(
-														"grow",
-														validVersion(value) ||
-														"border-destructive ring-destructive text-destructive",
-													)}
-													options={
-														versionCandidatePerPackage.get(value.name) ?? []
-													}
-													onChange={(value) =>
-														packagesListContext.update(id, (old) => ({
-															...old,
-															range: value,
-														}))
-													}
-												/>
-											</div>
-										</td>
-									</>
-								)}
-							/>
+								<ReorderableList
+									context={packagesListContext}
+									renderItem={(value, id) => (
+										<>
+											<td>
+												<div className={"flex"}>
+													<Autocomplete
+														value={value.name}
+														className={"grow"}
+														options={packageCandidates}
+														onChange={(value) =>
+															packagesListContext.update(id, (old) => ({
+																...old,
+																name: value,
+															}))
+														}
+													/>
+												</div>
+											</td>
+											<td>
+												<div className={"flex"}>
+													<Autocomplete
+														value={value.range}
+														className={cn(
+															"grow",
+															validVersion(value) ||
+																"border-destructive ring-destructive text-destructive",
+														)}
+														options={
+															versionCandidatePerPackage.get(value.name) ?? []
+														}
+														onChange={(value) =>
+															packagesListContext.update(id, (old) => ({
+																...old,
+																range: value,
+															}))
+														}
+													/>
+												</div>
+											</td>
+										</>
+									)}
+								/>
 							</tbody>
 						</table>
 					</div>
@@ -939,26 +934,26 @@ function TemplateEditor({
 					<div className={"w-full max-h-[30vh] overflow-y-auto shrink"}>
 						<table className={"w-full"}>
 							<tbody>
-							<ReorderableList
-								context={unityPackagesListContext}
-								ifEmpty={() => (
-									<td className={"text-center"}>
-										{tc("templates:dialog:no unitypackages")}
-									</td>
-								)}
-								renderItem={(value) => (
-									<td>
-										<div className={"flex"}>
-											<Input
-												type={"text"}
-												value={value}
-												className={"grow"}
-												disabled
-											/>
-										</div>
-									</td>
-								)}
-							/>
+								<ReorderableList
+									context={unityPackagesListContext}
+									ifEmpty={() => (
+										<td className={"text-center"}>
+											{tc("templates:dialog:no unitypackages")}
+										</td>
+									)}
+									renderItem={(value) => (
+										<td>
+											<div className={"flex"}>
+												<Input
+													type={"text"}
+													value={value}
+													className={"grow"}
+													disabled
+												/>
+											</div>
+										</td>
+									)}
+								/>
 							</tbody>
 						</table>
 					</div>

--- a/vrc-get-gui/app/_main/packages/user-packages/index.tsx
+++ b/vrc-get-gui/app/_main/packages/user-packages/index.tsx
@@ -16,7 +16,6 @@ import {
 	Dialog,
 	DialogClose,
 	DialogContent,
-	DialogDescription,
 	DialogFooter,
 	DialogTitle,
 	DialogTrigger,
@@ -220,14 +219,14 @@ function PackageRow({
 							<DialogTitle>
 								{tc("user packages:dialog:remove package")}
 							</DialogTitle>
-							<DialogDescription>
+							<div>
 								<p className={"whitespace-normal font-normal"}>
 									{tc("user packages:dialog:confirm remove description", {
 										name: pkgDisplayNames,
 										path: pkg.path,
 									})}
 								</p>
-							</DialogDescription>
+							</div>
 							<DialogFooter>
 								<DialogClose asChild>
 									<Button>{tc("general:button:cancel")}</Button>

--- a/vrc-get-gui/app/_main/projects/-create-project.tsx
+++ b/vrc-get-gui/app/_main/projects/-create-project.tsx
@@ -6,7 +6,6 @@ import { VStack } from "@/components/layout";
 import { TemplateSelect } from "@/components/TemplateSelect";
 import { Button } from "@/components/ui/button";
 import {
-	DialogDescription,
 	DialogFooter,
 	DialogTitle,
 } from "@/components/ui/dialog";
@@ -79,7 +78,7 @@ function DialogBase({
 	return (
 		<>
 			<DialogTitle>{tc("projects:create new project")}</DialogTitle>
-			<DialogDescription>{children}</DialogDescription>
+			<div>{children}</div>
 			<DialogFooter className={"gap-2"}>
 				<Button onClick={close} disabled={!close}>
 					{tc("general:button:cancel")}

--- a/vrc-get-gui/app/_main/projects/-create-project.tsx
+++ b/vrc-get-gui/app/_main/projects/-create-project.tsx
@@ -5,10 +5,7 @@ import { useEffect, useId, useMemo, useState } from "react";
 import { VStack } from "@/components/layout";
 import { TemplateSelect } from "@/components/TemplateSelect";
 import { Button } from "@/components/ui/button";
-import {
-	DialogFooter,
-	DialogTitle,
-} from "@/components/ui/dialog";
+import { DialogFooter, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import {
 	Select,

--- a/vrc-get-gui/app/_main/projects/-project-row.tsx
+++ b/vrc-get-gui/app/_main/projects/-project-row.tsx
@@ -14,7 +14,6 @@ import { OpenUnityButton } from "@/components/OpenUnityButton";
 import { RemoveProjectDialog } from "@/components/RemoveProjectDialog";
 import { Button } from "@/components/ui/button";
 import {
-	DialogDescription,
 	DialogFooter,
 	DialogTitle,
 } from "@/components/ui/dialog";
@@ -399,9 +398,9 @@ function ConfirmVpmMigrationDialog({
 	return (
 		<div className={"contents whitespace-normal"}>
 			<DialogTitle>{tc("projects:dialog:vpm migrate header")}</DialogTitle>
-			<DialogDescription>
+			<div>
 				<p>{tc("projects:dialog:vpm migrate description")}</p>
-			</DialogDescription>
+			</div>
 			<DialogFooter className={"gap-1"}>
 				<Button onClick={() => dialog.close(null)}>
 					{tc("general:button:cancel")}
@@ -424,9 +423,9 @@ function VpmMigrationUpdating() {
 	return (
 		<div className={"contents whitespace-normal"}>
 			<DialogTitle>{tc("projects:dialog:vpm migrate header")}</DialogTitle>
-			<DialogDescription>
+			<div>
 				<p>{tc("projects:migrating...")}</p>
-			</DialogDescription>
+			</div>
 		</div>
 	);
 }

--- a/vrc-get-gui/app/_main/projects/-project-row.tsx
+++ b/vrc-get-gui/app/_main/projects/-project-row.tsx
@@ -13,10 +13,7 @@ import { FavoriteStarToggleButton } from "@/components/FavoriteStarButton";
 import { OpenUnityButton } from "@/components/OpenUnityButton";
 import { RemoveProjectDialog } from "@/components/RemoveProjectDialog";
 import { Button } from "@/components/ui/button";
-import {
-	DialogFooter,
-	DialogTitle,
-} from "@/components/ui/dialog";
+import { DialogFooter, DialogTitle } from "@/components/ui/dialog";
 import {
 	DropdownMenu,
 	DropdownMenuContent,

--- a/vrc-get-gui/app/_main/projects/manage/-copy-project.tsx
+++ b/vrc-get-gui/app/_main/projects/manage/-copy-project.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState } from "react";
 import { VStack } from "@/components/layout";
 import { Button } from "@/components/ui/button";
 import {
-	DialogDescription,
 	DialogFooter,
 	DialogTitle,
 } from "@/components/ui/dialog";
@@ -113,7 +112,7 @@ function CopyProjectNameDialog({
 			<DialogTitle>
 				{tc("projects:dialog:copy project", { name: oldName })}
 			</DialogTitle>
-			<DialogDescription>
+			<div>
 				<VStack>
 					<Input
 						value={projectNameRaw}
@@ -149,7 +148,7 @@ function CopyProjectNameDialog({
 						projectNameCheckState={projectNameCheckState}
 					/>
 				</VStack>
-			</DialogDescription>
+			</div>
 			<DialogFooter className={"gap-2"}>
 				<Button onClick={() => dialog.close(null)}>
 					{tc("general:button:cancel")}
@@ -199,7 +198,7 @@ export function CopyingDialog({
 			<DialogTitle>
 				{tc("projects:dialog:copy project", { name: oldName })}
 			</DialogTitle>
-			<DialogDescription>
+			<div>
 				<p>{tc("projects:dialog:copying...")}</p>
 				<p>
 					{tc("projects:dialog:proceed k/n", {
@@ -209,7 +208,7 @@ export function CopyingDialog({
 				</p>
 				<Progress value={progress.proceed} max={progress.total} />
 				<p>{tc("projects:do not close")}</p>
-			</DialogDescription>
+			</div>
 			<DialogFooter className={"gap-2"}>
 				<Button disabled>{tc("general:button:cancel")}</Button>
 			</DialogFooter>

--- a/vrc-get-gui/app/_main/projects/manage/-copy-project.tsx
+++ b/vrc-get-gui/app/_main/projects/manage/-copy-project.tsx
@@ -3,10 +3,7 @@ import type { NavigateFn } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
 import { VStack } from "@/components/layout";
 import { Button } from "@/components/ui/button";
-import {
-	DialogFooter,
-	DialogTitle,
-} from "@/components/ui/dialog";
+import { DialogFooter, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Progress } from "@/components/ui/progress";
 import { assertNever } from "@/lib/assert-never";

--- a/vrc-get-gui/app/_main/projects/manage/-unity-migration.tsx
+++ b/vrc-get-gui/app/_main/projects/manage/-unity-migration.tsx
@@ -3,7 +3,6 @@ import React, { Fragment, useEffect, useState } from "react";
 import { BackupProjectDialog } from "@/components/BackupProjectDialog";
 import { Button } from "@/components/ui/button";
 import {
-	DialogDescription,
 	DialogFooter,
 	DialogTitle,
 } from "@/components/ui/dialog";
@@ -206,14 +205,14 @@ function NoExactUnity2022Dialog({
 	return (
 		<>
 			<DialogTitle>{header}</DialogTitle>
-			<DialogDescription>
+			<div>
 				<p>
 					{tc(
 						"projects:manage:dialog:exact version unity not found for patch migration description",
 						{ unity: expectedVersion },
 					)}
 				</p>
-			</DialogDescription>
+			</div>
 			<DialogFooter className={"gap-2"}>
 				{installWithUnityHubLink && (
 					<Button
@@ -242,11 +241,11 @@ function MigrationConfirmMigrationPatchDialog({
 	return (
 		<>
 			<DialogTitle>{header}</DialogTitle>
-			<DialogDescription>
+			<div>
 				<p className={"text-destructive"}>
 					{tc("projects:dialog:migrate unity2022 patch description", { unity })}
 				</p>
-			</DialogDescription>
+			</div>
 			<DialogFooter>
 				<Button onClick={() => dialog.close(null)} className="mr-1">
 					{tc("general:button:cancel")}
@@ -269,9 +268,9 @@ function MigrationConfirmMigrationDialog({
 	return (
 		<>
 			<DialogTitle>{header}</DialogTitle>
-			<DialogDescription>
+			<div>
 				<p>{tc("projects:dialog:vpm migrate description")}</p>
-			</DialogDescription>
+			</div>
 			<DialogFooter className={"gap-1"}>
 				<Button onClick={() => dialog.close(null)}>
 					{tc("general:button:cancel")}
@@ -330,9 +329,9 @@ function UnityVersionChange({
 	return (
 		<>
 			<DialogTitle>{header}</DialogTitle>
-			<DialogDescription>
+			<div>
 				<p className={"text-destructive"}>{mainMessage}</p>
-			</DialogDescription>
+			</div>
 			<DialogFooter>
 				<Button onClick={() => dialog.close(null)} className="mr-1">
 					{tc("general:button:cancel")}
@@ -378,7 +377,7 @@ export function MigrationCopyingDialog({
 	return (
 		<>
 			<DialogTitle>{header}</DialogTitle>
-			<DialogDescription>
+			<div>
 				<p>{tc("projects:pre-migrate copying...")}</p>
 				<p>
 					{tc("projects:dialog:proceed k/n", {
@@ -388,7 +387,7 @@ export function MigrationCopyingDialog({
 				</p>
 				<Progress value={progress.proceed} max={progress.total} />
 				<p>{tc("projects:do not close")}</p>
-			</DialogDescription>
+			</div>
 		</>
 	);
 }
@@ -397,10 +396,10 @@ function MigrationMigratingDialog({ header }: { header: React.ReactNode }) {
 	return (
 		<>
 			<DialogTitle>{header}</DialogTitle>
-			<DialogDescription>
+			<div>
 				<p>{tc("projects:migrating...")}</p>
 				<p>{tc("projects:do not close")}</p>
-			</DialogDescription>
+			</div>
 		</>
 	);
 }
@@ -564,7 +563,7 @@ function MigrationCallingUnityForMigrationDialog({
 	return (
 		<>
 			<DialogTitle>{header}</DialogTitle>
-			<DialogDescription>
+			<div>
 				<p>{tc("projects:manage:dialog:unity migrate finalizing...")}</p>
 				<p>{tc("projects:do not close")}</p>
 				{/* TODO: use ScrollArea (I failed to use it inside dialog) */}
@@ -581,7 +580,7 @@ function MigrationCallingUnityForMigrationDialog({
 					))}
 					<div ref={ref} />
 				</pre>
-			</DialogDescription>
+			</div>
 		</>
 	);
 }

--- a/vrc-get-gui/app/_main/projects/manage/-unity-migration.tsx
+++ b/vrc-get-gui/app/_main/projects/manage/-unity-migration.tsx
@@ -2,10 +2,7 @@ import type { NavigateFn } from "@tanstack/react-router";
 import React, { Fragment, useEffect, useState } from "react";
 import { BackupProjectDialog } from "@/components/BackupProjectDialog";
 import { Button } from "@/components/ui/button";
-import {
-	DialogFooter,
-	DialogTitle,
-} from "@/components/ui/dialog";
+import { DialogFooter, DialogTitle } from "@/components/ui/dialog";
 import { Progress } from "@/components/ui/progress";
 import { UnitySelectorDialog } from "@/components/unity-selector-dialog";
 import { assertNever } from "@/lib/assert-never";

--- a/vrc-get-gui/app/_main/projects/manage/-use-package-change.tsx
+++ b/vrc-get-gui/app/_main/projects/manage/-use-package-change.tsx
@@ -774,7 +774,7 @@ function MissingDependenciesDialog({
 				<CircleAlert className="size-6 inline" />{" "}
 				{tc("projects:manage:dialog:missing dependencies")}
 			</DialogTitle>
-			<DialogDescription>
+			<div>
 				<p className={"whitespace-normal"}>
 					{tc("projects:manage:dialog:missing dependencies description")}
 				</p>
@@ -785,7 +785,7 @@ function MissingDependenciesDialog({
 						</li>
 					))}
 				</ul>
-			</DialogDescription>
+			</div>
 			<DialogFooter>
 				<Button onClick={() => dialog.close()}>
 					{tc("general:button:close")}

--- a/vrc-get-gui/app/_main/projects/manage/index.tsx
+++ b/vrc-get-gui/app/_main/projects/manage/index.tsx
@@ -25,7 +25,6 @@ import { RemoveProjectDialog } from "@/components/RemoveProjectDialog";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import {
-	DialogDescription,
 	DialogFooter,
 	DialogTitle,
 } from "@/components/ui/dialog";
@@ -606,12 +605,12 @@ function LaunchSettings({
 		<>
 			<DialogTitle>{tc("projects:dialog:launch options")}</DialogTitle>
 			{/* TODO: use ScrollArea (I failed to use it inside dialog) */}
-			<DialogDescription className={"max-h-[50dvh] overflow-y-auto"}>
+			<div className={"max-h-[50dvh] overflow-y-auto"}>
 				<h3 className={"text-lg"}>
 					{tc("projects:dialog:command-line arguments")}
 				</h3>
 				<UnityArgumentsSettings context={context} />
-			</DialogDescription>
+			</div>
 			<DialogFooter>
 				<Button onClick={() => dialog.close(false)} variant={"destructive"}>
 					{tc("general:button:cancel")}

--- a/vrc-get-gui/app/_main/projects/manage/index.tsx
+++ b/vrc-get-gui/app/_main/projects/manage/index.tsx
@@ -24,10 +24,7 @@ import { OpenUnityButton } from "@/components/OpenUnityButton";
 import { RemoveProjectDialog } from "@/components/RemoveProjectDialog";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
-import {
-	DialogFooter,
-	DialogTitle,
-} from "@/components/ui/dialog";
+import { DialogFooter, DialogTitle } from "@/components/ui/dialog";
 import {
 	DropdownMenu,
 	DropdownMenuContent,

--- a/vrc-get-gui/app/_main/settings/index.tsx
+++ b/vrc-get-gui/app/_main/settings/index.tsx
@@ -28,7 +28,6 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
-	DialogDescription,
 	DialogFooter,
 	DialogTitle,
 } from "@/components/ui/dialog";
@@ -455,9 +454,9 @@ function LaunchArgumentsEditDialogBody({
 				{tc("settings:dialog:default launch arguments")}
 			</DialogTitle>
 			{/* TODO: use ScrollArea (I failed to use it inside dialog) */}
-			<DialogDescription className={"max-h-[50dvh] overflow-y-auto"}>
+			<div className={"max-h-[50dvh] overflow-y-auto"}>
 				<UnityArgumentsSettings context={context} />
-			</DialogDescription>
+			</div>
 			<DialogFooter>
 				<Button onClick={() => dialog.close(false)} variant={"destructive"}>
 					{tc("general:button:cancel")}

--- a/vrc-get-gui/app/_main/settings/index.tsx
+++ b/vrc-get-gui/app/_main/settings/index.tsx
@@ -27,10 +27,7 @@ import { ScrollPageContainer } from "@/components/ScrollPageContainer";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
-import {
-	DialogFooter,
-	DialogTitle,
-} from "@/components/ui/dialog";
+import { DialogFooter, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import {
 	Tooltip,

--- a/vrc-get-gui/components/BackupProjectDialog.tsx
+++ b/vrc-get-gui/components/BackupProjectDialog.tsx
@@ -1,10 +1,7 @@
 import type React from "react";
 import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
-import {
-	DialogFooter,
-	DialogTitle,
-} from "@/components/ui/dialog";
+import { DialogFooter, DialogTitle } from "@/components/ui/dialog";
 import { Progress } from "@/components/ui/progress";
 import type { TauriCreateBackupProgress } from "@/lib/bindings";
 import { commands } from "@/lib/bindings";

--- a/vrc-get-gui/components/BackupProjectDialog.tsx
+++ b/vrc-get-gui/components/BackupProjectDialog.tsx
@@ -2,7 +2,6 @@ import type React from "react";
 import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
-	DialogDescription,
 	DialogFooter,
 	DialogTitle,
 } from "@/components/ui/dialog";
@@ -69,7 +68,7 @@ export function BackupProjectDialog({
 	return (
 		<div className={"contents whitespace-normal"}>
 			<DialogTitle>{header ?? tc("projects:dialog:backup header")}</DialogTitle>
-			<DialogDescription>
+			<div>
 				<p>{tc("projects:dialog:creating backup...")}</p>
 				<p>
 					{tc("projects:dialog:proceed k/n", {
@@ -81,7 +80,7 @@ export function BackupProjectDialog({
 					{progress.last_proceed || "Collecting files..."}
 				</p>
 				<Progress value={progress.proceed} max={progress.total} />
-			</DialogDescription>
+			</div>
 			<DialogFooter>
 				<Button className="mr-1" onClick={() => cancelRef.current?.()}>
 					{tc("general:button:cancel")}

--- a/vrc-get-gui/components/CheckForUpdateMessage.tsx
+++ b/vrc-get-gui/components/CheckForUpdateMessage.tsx
@@ -1,10 +1,7 @@
 import React, { useState } from "react";
 import { ExternalLink } from "@/components/ExternalLink";
 import { Button } from "@/components/ui/button";
-import {
-	DialogFooter,
-	DialogTitle,
-} from "@/components/ui/dialog";
+import { DialogFooter, DialogTitle } from "@/components/ui/dialog";
 import { Progress } from "@/components/ui/progress";
 import { assertNever } from "@/lib/assert-never";
 import type { CheckForUpdateResponse } from "@/lib/bindings";

--- a/vrc-get-gui/components/CheckForUpdateMessage.tsx
+++ b/vrc-get-gui/components/CheckForUpdateMessage.tsx
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 import { ExternalLink } from "@/components/ExternalLink";
 import { Button } from "@/components/ui/button";
 import {
-	DialogDescription,
 	DialogFooter,
 	DialogTitle,
 } from "@/components/ui/dialog";
@@ -104,7 +103,7 @@ export function CheckForUpdateMessage({
 			return (
 				<>
 					<DialogTitle>{tc("check update:dialog:title")}</DialogTitle>
-					<DialogDescription>
+					<div>
 						<p>{tc("check update:dialog:new version description")}</p>
 						<p>
 							{tc("check update:dialog:current version")}{" "}
@@ -122,7 +121,7 @@ export function CheckForUpdateMessage({
 								}
 							/>
 						</p>
-					</DialogDescription>
+					</div>
 					<DialogFooter className={"gap-2"}>
 						<Button onClick={() => dialog.close(false)}>
 							{tc("check update:dialog:dismiss")}
@@ -137,22 +136,22 @@ export function CheckForUpdateMessage({
 			return (
 				<>
 					<DialogTitle>{tc("check update:dialog:title")}</DialogTitle>
-					<DialogDescription>
+					<div>
 						<p>{tc("check update:dialog:downloading...")}</p>
 						<Progress
 							value={confirmStatus.downloaded}
 							max={confirmStatus.total}
 						/>
-					</DialogDescription>
+					</div>
 				</>
 			);
 		case "waitingForRelaunch":
 			return (
 				<>
 					<DialogTitle>{tc("check update:dialog:title")}</DialogTitle>
-					<DialogDescription>
+					<div>
 						<p>{tc("check update:dialog:relaunching...")}</p>
-					</DialogDescription>
+					</div>
 				</>
 			);
 	}

--- a/vrc-get-gui/components/RemoveProjectDialog.tsx
+++ b/vrc-get-gui/components/RemoveProjectDialog.tsx
@@ -2,7 +2,6 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useLocation, useRouter } from "@tanstack/react-router";
 import { Button } from "@/components/ui/button";
 import {
-	DialogDescription,
 	DialogFooter,
 	DialogTitle,
 } from "@/components/ui/dialog";
@@ -63,7 +62,7 @@ export function RemoveProjectDialog({
 	return (
 		<div className={"contents whitespace-normal"}>
 			<DialogTitle>{tc("projects:remove project")}</DialogTitle>
-			<DialogDescription>
+			<div>
 				{removeProject.isPending ? (
 					<p className={"font-normal"}>{tc("projects:dialog:removing...")}</p>
 				) : (
@@ -73,7 +72,7 @@ export function RemoveProjectDialog({
 						})}
 					</p>
 				)}
-			</DialogDescription>
+			</div>
 			<DialogFooter className={"flex gap-2"}>
 				<Button
 					onClick={() => dialog.close(false)}

--- a/vrc-get-gui/components/RemoveProjectDialog.tsx
+++ b/vrc-get-gui/components/RemoveProjectDialog.tsx
@@ -1,10 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useLocation, useRouter } from "@tanstack/react-router";
 import { Button } from "@/components/ui/button";
-import {
-	DialogFooter,
-	DialogTitle,
-} from "@/components/ui/dialog";
+import { DialogFooter, DialogTitle } from "@/components/ui/dialog";
 import { commands } from "@/lib/bindings";
 import type { DialogContext } from "@/lib/dialog";
 import { tc, tt } from "@/lib/i18n";

--- a/vrc-get-gui/components/SideBar.tsx
+++ b/vrc-get-gui/components/SideBar.tsx
@@ -27,7 +27,6 @@ import {
 	Dialog,
 	DialogClose,
 	DialogContent,
-	DialogDescription,
 	DialogFooter,
 	DialogHeader,
 	DialogTrigger,
@@ -153,9 +152,9 @@ function BadHostNameDialogButton() {
 						{tc("sidebar:dialog:bad hostname")}
 					</h1>
 				</DialogHeader>
-				<DialogDescription className={"whitespace-normal"}>
+				<div className={"whitespace-normal"}>
 					{tc("sidebar:dialog:bad hostname description")}
-				</DialogDescription>
+				</div>
 				<DialogFooter>
 					<DialogClose asChild>
 						<Button>{tc("general:button:close")}</Button>

--- a/vrc-get-gui/components/unity-selector-dialog.tsx
+++ b/vrc-get-gui/components/unity-selector-dialog.tsx
@@ -1,10 +1,7 @@
 import { useId, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import {
-	DialogFooter,
-	DialogTitle,
-} from "@/components/ui/dialog";
+import { DialogFooter, DialogTitle } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import type { DialogContext } from "@/lib/dialog";

--- a/vrc-get-gui/components/unity-selector-dialog.tsx
+++ b/vrc-get-gui/components/unity-selector-dialog.tsx
@@ -2,7 +2,6 @@ import { useId, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
-	DialogDescription,
 	DialogFooter,
 	DialogTitle,
 } from "@/components/ui/dialog";
@@ -37,7 +36,7 @@ export function UnitySelectorDialog({
 	return (
 		<div className={"contents whitespace-normal"}>
 			<DialogTitle>{tc("projects:dialog:select unity header")}</DialogTitle>
-			<DialogDescription>
+			<div>
 				<p>{tc("projects:dialog:multiple unity found")}</p>
 				{supportKeepUsing && (
 					<span className={"block my-2"}>
@@ -66,7 +65,7 @@ export function UnitySelectorDialog({
 						</div>
 					))}
 				</RadioGroup>
-			</DialogDescription>
+			</div>
 			<DialogFooter>
 				<Button onClick={() => dialog.close(null)} className="mr-2">
 					{tc("general:button:cancel")}

--- a/vrc-get-gui/lib/import-templates.tsx
+++ b/vrc-get-gui/lib/import-templates.tsx
@@ -1,10 +1,7 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import {
-	DialogFooter,
-	DialogTitle,
-} from "@/components/ui/dialog";
+import { DialogFooter, DialogTitle } from "@/components/ui/dialog";
 import {
 	commands,
 	type TauriImportDuplicated,

--- a/vrc-get-gui/lib/import-templates.tsx
+++ b/vrc-get-gui/lib/import-templates.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
-	DialogDescription,
 	DialogFooter,
 	DialogTitle,
 } from "@/components/ui/dialog";
@@ -75,7 +74,7 @@ export function AskOverride({
 	return (
 		<>
 			<DialogTitle>{tc("templates:dialog:duplicated")}</DialogTitle>
-			<DialogDescription className={"flex flex-col gap-2"}>
+			<div className={"flex flex-col gap-2"}>
 				<p className={"whitespace-normal font-normal"}>
 					{tc("templates:dialog:confirm update templates")}
 				</p>
@@ -132,7 +131,7 @@ export function AskOverride({
 						);
 					})}
 				</ul>
-			</DialogDescription>
+			</div>
 			<DialogFooter>
 				<Button
 					onClick={() => {

--- a/vrc-get-gui/lib/open-unity.tsx
+++ b/vrc-get-gui/lib/open-unity.tsx
@@ -1,6 +1,5 @@
 import { Button } from "@/components/ui/button";
 import {
-	DialogDescription,
 	DialogFooter,
 	DialogTitle,
 } from "@/components/ui/dialog";
@@ -155,13 +154,13 @@ function UnityInstallWindow({
 	return (
 		<>
 			<DialogTitle>{tc("projects:dialog:unity not found")}</DialogTitle>
-			<DialogDescription>
+			<div>
 				<p>
 					{tc("projects:dialog:unity version of the project not found", {
 						unity: expectedVersion,
 					})}
 				</p>
-			</DialogDescription>
+			</div>
 			<DialogFooter className={"gap-2"}>
 				<Button onClick={openUnityHub}>
 					{tc("projects:dialog:open unity hub")}
@@ -188,7 +187,7 @@ function AskForChinaRevision({
 			<DialogTitle>
 				{tc("projects:dialog:unity not found but china found")}
 			</DialogTitle>
-			<DialogDescription>
+			<div>
 				<p>
 					{tc(
 						"projects:dialog:unity version of the project not found but china found",
@@ -198,7 +197,7 @@ function AskForChinaRevision({
 						},
 					)}
 				</p>
-			</DialogDescription>
+			</div>
 			<DialogFooter className={"gap-2"}>
 				<Button onClick={() => dialog.close(true)}>
 					{tc("projects:dialog:use china version")}
@@ -225,7 +224,7 @@ function AskForInternationalRevision({
 			<DialogTitle>
 				{tc("projects:dialog:unity not found but international found")}
 			</DialogTitle>
-			<DialogDescription>
+			<div>
 				<p>
 					{tc(
 						"projects:dialog:unity version of the project not found but international found",
@@ -235,7 +234,7 @@ function AskForInternationalRevision({
 						},
 					)}
 				</p>
-			</DialogDescription>
+			</div>
 			<DialogFooter className={"gap-2"}>
 				<Button onClick={() => dialog.close(true)}>
 					{tc("projects:dialog:use international version")}

--- a/vrc-get-gui/lib/open-unity.tsx
+++ b/vrc-get-gui/lib/open-unity.tsx
@@ -1,8 +1,5 @@
 import { Button } from "@/components/ui/button";
-import {
-	DialogFooter,
-	DialogTitle,
-} from "@/components/ui/dialog";
+import { DialogFooter, DialogTitle } from "@/components/ui/dialog";
 import { UnitySelectorDialog } from "@/components/unity-selector-dialog";
 import { commands, type TauriUnityVersions } from "@/lib/bindings";
 import { type DialogContext, openSingleDialog } from "@/lib/dialog";


### PR DESCRIPTION
close #2515
ref: #2516

- `text-muted-foreground`の色指定が機能していなかったため今まで表面化していなかったが、`DialogDescription`は`text-muted-foreground`を指定しており、 #2516 をmergeするとダイアログの大半の色が変化する
- そもそも`DialogDescription`はHeader以下においてDialogの概要を説明するためのコンポーネントであり、contentの全体をwrapするためのコンポーネントではないため、用法が間違っている
- 以上のことから`DialogHeader`以下にない`DialogDescription`を削除した


