### PR TITLE
fix: fix "[object Object]" appearing as an error message

### DIFF
--- a/CHANGELOG-gui.md
+++ b/CHANGELOG-gui.md
@@ -51,6 +51,7 @@ The format is based on [Keep a Changelog].
 - Default file names in save dialogs now include the appropriate file extension `#2846`
   - Template export now defaults to `{template name}.alcomtemplate`
   - Repository list export now defaults to `repositories.txt`
+- Uninformative `[object Object]` appearing as an error message `#2848`
 
 ### Security
 

--- a/vrc-get-gui/app/-error.tsx
+++ b/vrc-get-gui/app/-error.tsx
@@ -14,8 +14,12 @@ export default function ErrorPage({
 	}, [error]);
 
 	// When there is overridden toString, use it. if not, use stringify
-	const errorMessage = error.toString === Object.prototype.toString ? JSON.stringify(error) : error.toString();
-	const errorStack = 'stack' in error ? `${error.stack}` : "No stacktrace provided";
+	const errorMessage =
+		error.toString === Object.prototype.toString
+			? JSON.stringify(error)
+			: error.toString();
+	const errorStack =
+		"stack" in error ? `${error.stack}` : "No stacktrace provided";
 
 	const openIssue = () => {
 		try {

--- a/vrc-get-gui/app/-error.tsx
+++ b/vrc-get-gui/app/-error.tsx
@@ -6,15 +6,16 @@ import globalInfo from "@/lib/global-info";
 export default function ErrorPage({
 	error,
 }: {
-	error: Error;
+	error: object;
 	reset?: () => void;
 }) {
 	useEffect(() => {
 		console.error(error);
 	}, [error]);
 
-	const errorMessage = `${error}`;
-	const errorStack = `${error.stack}`;
+	// When there is overridden toString, use it. if not, use stringify
+	const errorMessage = error.toString === Object.prototype.toString ? JSON.stringify(error) : error.toString();
+	const errorStack = 'stack' in error ? `${error.stack}` : "No stacktrace provided";
 
 	const openIssue = () => {
 		try {


### PR DESCRIPTION
We show JSON instead when no meaningful message can be retrieved