### PR TITLE
chore!: package hash check is now enforced when installing package

### DIFF
--- a/CHANGELOG-gui.md
+++ b/CHANGELOG-gui.md
@@ -53,6 +53,9 @@ The format is based on [Keep a Changelog].
   - Repository list export now defaults to `repositories.txt`
 
 ### Security
+- Package hash checks are now enforced when installing packages `#2849`
+  - It has been about two years since the error message for package hash mismatches was introduced.
+  - It is now enforced for security.
 
 ## [1.1.5] - 2025-11-16
 - Fix package version selector dropdown exceeding window height [`#2589`](https://github.com/vrc-get/vrc-get/pull/2589)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ The format is based on [Keep a Changelog].
 - Unclear error message for invalid version name or version range `#2842`
 
 ### Security
+- Package hash checks are now enforced when installing packages `#2849`
+  - It has been about two years since the error message for package hash mismatches was introduced.
+  - It is now enforced for security.
 
 ## [1.9.1] - 2025-07-28
 ### Changed

--- a/vrc-get-vpm/src/environment/package_installer.rs
+++ b/vrc-get-vpm/src/environment/package_installer.rs
@@ -7,7 +7,7 @@ use crate::{HttpClient, PackageInfo, PackageManifest, io};
 use futures::prelude::*;
 use hex::FromHex;
 use indexmap::IndexMap;
-use log::{debug, error};
+use log::debug;
 use std::io::SeekFrom;
 use std::path::{Path, PathBuf};
 use std::pin::pin;
@@ -136,12 +136,16 @@ async fn get_package<T: HttpClient>(
             .and_then(|x| <[u8; 256 / 8] as FromHex>::from_hex(x).ok())
             && repo_hash != zip_hash
         {
-            error!(
-                "Package hash mismatched! This will be hard error in the future!: {} v{}",
-                package.name(),
-                package.version()
-            );
-            //return None;
+            drop(zip_file);
+            io.remove_file(&zip_path).await.ok();
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "Downloaded file for {}@{} has an unexpected SHA256 hash. his may be the repository owner's fault, or the repository or package may be compromised.",
+                    package.name(),
+                    package.version()
+                ),
+            ));
         }
 
         Ok(zip_file)


### PR DESCRIPTION
It has been about two years since the error message was introduced in #1183.
It's time to enforce it for security.