### PR TITLE
fix(style): keep react-toastify toasts in sync with dark mode

### DIFF
--- a/vrc-get-gui/app/globals.css
+++ b/vrc-get-gui/app/globals.css
@@ -188,7 +188,7 @@
 	}
 }
 
-:root {
+body {
 	--toastify-font-family: var(--font-sans);
 	--toastify-color-light: var(--background);
 	/*--toastify-color-info: #3498db;*/


### PR DESCRIPTION
react-toastify 11.1.0 changed its CSS injection to append style to the end of <head> on mount, so its `:root` variable defaults started overriding ours by source order, and toasts stopped following the dark theme.

Declaring the `--toastify-*` overrides on `body` instead of `:root` makes toasts inherit them regardless of stylesheet order, since react-toastify only declares these variables on `:root`.

https://github.com/fkhadra/react-toastify/releases/tag/v11.1.0
https://github.com/fkhadra/react-toastify/compare/v11.0.5...v11.1.0

https://fkhadra.github.io/react-toastify/how-to-style#override-css-variables

fix #2886 

<img width="2305" height="1185" alt="image" src="https://github.com/user-attachments/assets/469079b8-72be-4653-9b72-af8e995bd66b" />