### PR TITLE
fix: panic with repositories with no id nor url

### DIFF
--- a/CHANGELOG-gui.md
+++ b/CHANGELOG-gui.md
@@ -21,6 +21,8 @@ The format is based on [Keep a Changelog].
 - Several Linux Distributions are broken
   - RPM was broken and unable to install because it includes several directories for bundle `#2970`
   - AppImage did not include webkitgtk and other libraries pure KDE environment do not likely to have `#2981`
+- Panics when there is repository with no id nor url specified `#3002`
+  - We ignore such repositories instead. It's likely be a borken repository.
 
 ### Security
 

--- a/vrc-get-gui/src/commands/environment/packages.rs
+++ b/vrc-get-gui/src/commands/environment/packages.rs
@@ -89,6 +89,7 @@ pub async fn environment_repositories_info(
         .get_user_repos()
         .iter()
         .enumerate()
+        .filter(|(_, repo)| repo.id().is_some() || repo.url().is_some())
         .map(|(index, x)| {
             let id = x.id().or(x.url().map(Url::as_str)).unwrap();
             TauriUserRepository {


### PR DESCRIPTION
Fix #2955