### PR TITLE
Add shift-click range selection for package checkboxes in Manage Packages

### DIFF
--- a/CHANGELOG-gui.md
+++ b/CHANGELOG-gui.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog].
 - ALCOM / vrc-get now prevents installing VRCSDK for Unity 2022 to Unity 6000.x `#3006`
   - This prevents installing VRCSDK to incompatible Unity.
   - This check is not enforced error, you can ignore the error for testing purposes.
+- Shift-click a package checkbox in Manage Packages to select the range between it and the last clicked package `#3030`
 
 ### Deprecated
 

--- a/vrc-get-gui/app/_main/projects/manage/-package-list-card.tsx
+++ b/vrc-get-gui/app/_main/projects/manage/-package-list-card.tsx
@@ -18,6 +18,7 @@ import type React from "react";
 import {
 	memo,
 	useCallback,
+	useEffect,
 	useLayoutEffect,
 	useMemo,
 	useRef,
@@ -108,14 +109,11 @@ export const PackageListCard = memo(function PackageListCard({
 		lastSelectedPackageIdRef.current = null;
 	}, []);
 
-	const lastFilterInputsRef = useRef({ search, packageRowsData });
-	if (
-		lastFilterInputsRef.current.search !== search ||
-		lastFilterInputsRef.current.packageRowsData !== packageRowsData
-	) {
-		lastFilterInputsRef.current = { search, packageRowsData };
+	// biome-ignore lint/correctness/useExhaustiveDependencies(search): watched to trigger the reset, not read in the body
+	// biome-ignore lint/correctness/useExhaustiveDependencies(packageRowsData): watched to trigger the reset, not read in the body
+	useEffect(() => {
 		lastSelectedPackageIdRef.current = null;
-	}
+	}, [search, packageRowsData]);
 
 	const bulkUpdateMode = useMemo(() => {
 		const packageRowByPackageId = new Map(

--- a/vrc-get-gui/app/_main/projects/manage/-package-list-card.tsx
+++ b/vrc-get-gui/app/_main/projects/manage/-package-list-card.tsx
@@ -94,6 +94,7 @@ export const PackageListCard = memo(function PackageListCard({
 		[],
 	);
 	const [showHiddenPackages, setShowHiddenPackages] = useState(false);
+	const lastSelectedPackageIdRef = useRef<string | null>(null);
 
 	const bulkUpdatePackageIds = useMemo(() => {
 		const packageIds = new Set(packageRowsData.map((p) => p.id));
@@ -101,11 +102,10 @@ export const PackageListCard = memo(function PackageListCard({
 		return bulkUpdatePackageIdsRaw.filter((pkgId) => packageIds.has(pkgId));
 	}, [packageRowsData, bulkUpdatePackageIdsRaw]);
 
-	useDocumentEvent(
-		"post-package-changes",
-		() => setBulkUpdatePackageIds([]),
-		[],
-	);
+	useDocumentEvent("post-package-changes", () => {
+		setBulkUpdatePackageIds([]);
+		lastSelectedPackageIdRef.current = null;
+	}, []);
 
 	const bulkUpdateMode = useMemo(() => {
 		const packageRowByPackageId = new Map(
@@ -149,6 +149,19 @@ export const PackageListCard = memo(function PackageListCard({
 			.length;
 	}, [hiddenPackages, filteredPackageIds]);
 
+	const visibleOrderedPackageRows = useMemo(() => {
+		const hiddenIds = new Set(hiddenPackages.map((row) => row.id));
+		const rows = packageRowsData.filter(
+			(row) => !hiddenIds.has(row.id) && filteredPackageIds.has(row.id),
+		);
+		if (showHiddenPackages) {
+			rows.push(
+				...hiddenPackages.filter((row) => filteredPackageIds.has(row.id)),
+			);
+		}
+		return rows;
+	}, [packageRowsData, hiddenPackages, filteredPackageIds, showHiddenPackages]);
+
 	const toggleShowHiddenPackages = useCallback(() => {
 		setShowHiddenPackages((prev) => !prev);
 	}, []);
@@ -167,6 +180,69 @@ export const PackageListCard = memo(function PackageListCard({
 	const removeBulkUpdatePackage = useCallback((row: PackageRowInfo) => {
 		setBulkUpdatePackageIds((prev) => prev.filter((id) => id !== row.id));
 	}, []);
+
+	const latestSelectionStateRef = useRef({
+		bulkUpdatePackageIds,
+		visibleOrderedPackageRows,
+		bulkUpdateMode,
+	});
+	latestSelectionStateRef.current = {
+		bulkUpdatePackageIds,
+		visibleOrderedPackageRows,
+		bulkUpdateMode,
+	};
+
+	const onBulkUpdateCheckboxClick = useCallback(
+		(row: PackageRowInfo, shiftKey: boolean) => {
+			const {
+				bulkUpdatePackageIds,
+				visibleOrderedPackageRows,
+				bulkUpdateMode,
+			} = latestSelectionStateRef.current;
+			const nextChecked = !bulkUpdatePackageIds.includes(row.id);
+			const anchorId = lastSelectedPackageIdRef.current;
+
+			if (shiftKey && anchorId != null) {
+				const ids = visibleOrderedPackageRows.map((r) => r.id);
+				const anchorIndex = ids.indexOf(anchorId);
+				const targetIndex = ids.indexOf(row.id);
+
+				if (anchorIndex !== -1 && targetIndex !== -1) {
+					const [start, end] =
+						anchorIndex < targetIndex
+							? [anchorIndex, targetIndex]
+							: [targetIndex, anchorIndex];
+					const rangeRows = visibleOrderedPackageRows
+						.slice(start, end + 1)
+						.filter((r) =>
+							canBulkUpdate(bulkUpdateMode, bulkUpdateModeForPackage(r)),
+						);
+
+					setBulkUpdatePackageIds((prev) => {
+						const next = new Set(prev);
+						for (const rangeRow of rangeRows) {
+							if (nextChecked) {
+								next.add(rangeRow.id);
+							} else {
+								next.delete(rangeRow.id);
+							}
+						}
+						return [...next];
+					});
+					lastSelectedPackageIdRef.current = row.id;
+					return;
+				}
+			}
+
+			if (nextChecked) {
+				addBulkUpdatePackage(row);
+			} else {
+				removeBulkUpdatePackage(row);
+			}
+			lastSelectedPackageIdRef.current = row.id;
+		},
+		[addBulkUpdatePackage, removeBulkUpdatePackage],
+	);
 
 	// Fix scroll position when bulk update card visibility is changed
 	const scrollTableOuterRef = useRef<HTMLDivElement>(null);
@@ -267,8 +343,7 @@ export const PackageListCard = memo(function PackageListCard({
 											bulkUpdateMode,
 											bulkUpdateModeForPackage(row),
 										)}
-										addBulkUpdatePackage={addBulkUpdatePackage}
-										removeBulkUpdatePackage={removeBulkUpdatePackage}
+										onBulkUpdateCheckboxClick={onBulkUpdateCheckboxClick}
 									/>
 								</tr>
 							);
@@ -311,8 +386,7 @@ export const PackageListCard = memo(function PackageListCard({
 													bulkUpdateMode,
 													bulkUpdateModeForPackage(row),
 												)}
-												addBulkUpdatePackage={addBulkUpdatePackage}
-												removeBulkUpdatePackage={removeBulkUpdatePackage}
+												onBulkUpdateCheckboxClick={onBulkUpdateCheckboxClick}
 											/>
 										</tr>
 									))}
@@ -896,14 +970,12 @@ const PackageRow = memo(function PackageRow({
 	pkg,
 	bulkUpdateSelected,
 	bulkUpdateAvailable,
-	addBulkUpdatePackage,
-	removeBulkUpdatePackage,
+	onBulkUpdateCheckboxClick,
 }: {
 	pkg: PackageRowInfo;
 	bulkUpdateSelected: boolean;
 	bulkUpdateAvailable: boolean;
-	addBulkUpdatePackage: (pkg: PackageRowInfo) => void;
-	removeBulkUpdatePackage: (pkg: PackageRowInfo) => void;
+	onBulkUpdateCheckboxClick: (pkg: PackageRowInfo, shiftKey: boolean) => void;
 }) {
 	const cellClass = "p-3.5 compact:py-1";
 	const noGrowCellClass = `${cellClass} w-1`;
@@ -939,12 +1011,8 @@ const PackageRow = memo(function PackageRow({
 		});
 	};
 
-	const onClickBulkUpdate = () => {
-		if (bulkUpdateSelected) {
-			removeBulkUpdatePackage(pkg);
-		} else {
-			addBulkUpdatePackage(pkg);
-		}
+	const onClickBulkUpdateCheckbox = (e: React.MouseEvent) => {
+		onBulkUpdateCheckboxClick(pkg, e.shiftKey);
 	};
 
 	const documentationUrl = pkg.documentationUrl
@@ -958,7 +1026,7 @@ const PackageRow = memo(function PackageRow({
 				<div className={"flex items-center justify-center aspect-square"}>
 					<CheckboxDisabledIfLoading
 						checked={bulkUpdateSelected}
-						onCheckedChange={onClickBulkUpdate}
+						onClick={onClickBulkUpdateCheckbox}
 						disabled={!bulkUpdateAvailable}
 						className="hover:before:content-none"
 					/>

--- a/vrc-get-gui/app/_main/projects/manage/-package-list-card.tsx
+++ b/vrc-get-gui/app/_main/projects/manage/-package-list-card.tsx
@@ -103,14 +103,10 @@ export const PackageListCard = memo(function PackageListCard({
 		return bulkUpdatePackageIdsRaw.filter((pkgId) => packageIds.has(pkgId));
 	}, [packageRowsData, bulkUpdatePackageIdsRaw]);
 
-	useDocumentEvent(
-		"post-package-changes",
-		() => {
-			setBulkUpdatePackageIds([]);
-			lastSelectedPackageIdRef.current = null;
-		},
-		[],
-	);
+	useDocumentEvent("post-package-changes", () => {
+		setBulkUpdatePackageIds([]);
+		lastSelectedPackageIdRef.current = null;
+	}, []);
 
 	const lastFilterInputsRef = useRef({ search, packageRowsData });
 	if (
@@ -471,9 +467,9 @@ function ManagePackagesHeading({
 		const latestKey = stable ? "stableLatest" : "latest";
 		const packagesToInstall = packageRowsData
 			.map((row) => row[latestKey])
-			.filter<
-				PackageLatestInfo & { status: "upgradable" }
-			>((latest) => latest.status === "upgradable");
+			.filter<PackageLatestInfo & { status: "upgradable" }>(
+				(latest) => latest.status === "upgradable",
+			);
 		const packages: TauriPackage[] = packagesToInstall.map(
 			(latest) => latest.pkg,
 		);

--- a/vrc-get-gui/app/_main/projects/manage/-package-list-card.tsx
+++ b/vrc-get-gui/app/_main/projects/manage/-package-list-card.tsx
@@ -63,6 +63,7 @@ import { isFindKey, useDocumentEvent } from "@/lib/events";
 import { usePackageUpdateInProgress } from "@/lib/global-events";
 import { tc, tt } from "@/lib/i18n";
 import { toastThrownError } from "@/lib/toast";
+import { useEffectEvent } from "@/lib/use-effect-event";
 import { toVersionString } from "@/lib/version";
 import type {
 	PackageLatestInfo,
@@ -172,33 +173,8 @@ export const PackageListCard = memo(function PackageListCard({
 		setBulkUpdatePackageIds((prev) => prev.filter((id) => id !== row.id));
 	}, []);
 
-	const latestSelectionStateRef = useRef({
-		bulkUpdatePackageIds,
-		packageRowsData,
-		hiddenPackages,
-		filteredPackageIds,
-		showHiddenPackages,
-		bulkUpdateMode,
-	});
-	latestSelectionStateRef.current = {
-		bulkUpdatePackageIds,
-		packageRowsData,
-		hiddenPackages,
-		filteredPackageIds,
-		showHiddenPackages,
-		bulkUpdateMode,
-	};
-
-	const onBulkUpdateCheckboxClick = useCallback(
+	const onBulkUpdateCheckboxClick = useEffectEvent(
 		(row: PackageRowInfo, shiftKey: boolean) => {
-			const {
-				bulkUpdatePackageIds,
-				packageRowsData,
-				hiddenPackages,
-				filteredPackageIds,
-				showHiddenPackages,
-				bulkUpdateMode,
-			} = latestSelectionStateRef.current;
 			const nextChecked = !bulkUpdatePackageIds.includes(row.id);
 			const anchorId = lastSelectedPackageIdRef.current;
 
@@ -251,7 +227,6 @@ export const PackageListCard = memo(function PackageListCard({
 			}
 			lastSelectedPackageIdRef.current = row.id;
 		},
-		[addBulkUpdatePackage, removeBulkUpdatePackage],
 	);
 
 	// Fix scroll position when bulk update card visibility is changed

--- a/vrc-get-gui/app/_main/projects/manage/-package-list-card.tsx
+++ b/vrc-get-gui/app/_main/projects/manage/-package-list-card.tsx
@@ -102,10 +102,14 @@ export const PackageListCard = memo(function PackageListCard({
 		return bulkUpdatePackageIdsRaw.filter((pkgId) => packageIds.has(pkgId));
 	}, [packageRowsData, bulkUpdatePackageIdsRaw]);
 
-	useDocumentEvent("post-package-changes", () => {
-		setBulkUpdatePackageIds([]);
-		lastSelectedPackageIdRef.current = null;
-	}, []);
+	useDocumentEvent(
+		"post-package-changes",
+		() => {
+			setBulkUpdatePackageIds([]);
+			lastSelectedPackageIdRef.current = null;
+		},
+		[],
+	);
 
 	const bulkUpdateMode = useMemo(() => {
 		const packageRowByPackageId = new Map(
@@ -149,19 +153,6 @@ export const PackageListCard = memo(function PackageListCard({
 			.length;
 	}, [hiddenPackages, filteredPackageIds]);
 
-	const visibleOrderedPackageRows = useMemo(() => {
-		const hiddenIds = new Set(hiddenPackages.map((row) => row.id));
-		const rows = packageRowsData.filter(
-			(row) => !hiddenIds.has(row.id) && filteredPackageIds.has(row.id),
-		);
-		if (showHiddenPackages) {
-			rows.push(
-				...hiddenPackages.filter((row) => filteredPackageIds.has(row.id)),
-			);
-		}
-		return rows;
-	}, [packageRowsData, hiddenPackages, filteredPackageIds, showHiddenPackages]);
-
 	const toggleShowHiddenPackages = useCallback(() => {
 		setShowHiddenPackages((prev) => !prev);
 	}, []);
@@ -183,12 +174,18 @@ export const PackageListCard = memo(function PackageListCard({
 
 	const latestSelectionStateRef = useRef({
 		bulkUpdatePackageIds,
-		visibleOrderedPackageRows,
+		packageRowsData,
+		hiddenPackages,
+		filteredPackageIds,
+		showHiddenPackages,
 		bulkUpdateMode,
 	});
 	latestSelectionStateRef.current = {
 		bulkUpdatePackageIds,
-		visibleOrderedPackageRows,
+		packageRowsData,
+		hiddenPackages,
+		filteredPackageIds,
+		showHiddenPackages,
 		bulkUpdateMode,
 	};
 
@@ -196,13 +193,26 @@ export const PackageListCard = memo(function PackageListCard({
 		(row: PackageRowInfo, shiftKey: boolean) => {
 			const {
 				bulkUpdatePackageIds,
-				visibleOrderedPackageRows,
+				packageRowsData,
+				hiddenPackages,
+				filteredPackageIds,
+				showHiddenPackages,
 				bulkUpdateMode,
 			} = latestSelectionStateRef.current;
 			const nextChecked = !bulkUpdatePackageIds.includes(row.id);
 			const anchorId = lastSelectedPackageIdRef.current;
 
 			if (shiftKey && anchorId != null) {
+				const hiddenIds = new Set(hiddenPackages.map((r) => r.id));
+				const visibleOrderedPackageRows = packageRowsData.filter(
+					(r) => !hiddenIds.has(r.id) && filteredPackageIds.has(r.id),
+				);
+				if (showHiddenPackages) {
+					visibleOrderedPackageRows.push(
+						...hiddenPackages.filter((r) => filteredPackageIds.has(r.id)),
+					);
+				}
+
 				const ids = visibleOrderedPackageRows.map((r) => r.id);
 				const anchorIndex = ids.indexOf(anchorId);
 				const targetIndex = ids.indexOf(row.id);
@@ -477,9 +487,9 @@ function ManagePackagesHeading({
 		const latestKey = stable ? "stableLatest" : "latest";
 		const packagesToInstall = packageRowsData
 			.map((row) => row[latestKey])
-			.filter<PackageLatestInfo & { status: "upgradable" }>(
-				(latest) => latest.status === "upgradable",
-			);
+			.filter<
+				PackageLatestInfo & { status: "upgradable" }
+			>((latest) => latest.status === "upgradable");
 		const packages: TauriPackage[] = packagesToInstall.map(
 			(latest) => latest.pkg,
 		);

--- a/vrc-get-gui/app/_main/projects/manage/-package-list-card.tsx
+++ b/vrc-get-gui/app/_main/projects/manage/-package-list-card.tsx
@@ -112,6 +112,15 @@ export const PackageListCard = memo(function PackageListCard({
 		[],
 	);
 
+	const lastFilterInputsRef = useRef({ search, packageRowsData });
+	if (
+		lastFilterInputsRef.current.search !== search ||
+		lastFilterInputsRef.current.packageRowsData !== packageRowsData
+	) {
+		lastFilterInputsRef.current = { search, packageRowsData };
+		lastSelectedPackageIdRef.current = null;
+	}
+
 	const bulkUpdateMode = useMemo(() => {
 		const packageRowByPackageId = new Map(
 			packageRowsData.map((row) => [row.id, row]),


### PR DESCRIPTION
Adds shift-click range selection for the bulk-update checkboxes on the Manage Packages screen (matches the common file-explorer/email-client pattern).

## Changes
- Clicking a package checkbox toggles it and sets it as the selection anchor.
- Shift-clicking another checkbox selects (or deselects) every row between the anchor and the clicked row.
- Range selection respects the active search filter, the collapsed "hidden packages" section, and each row's bulk-update eligibility.
- Kept `PackageRow`'s existing memo-ization intact by reading current selection state from a ref instead of adding it as a callback dependency, so unrelated rows don't re-render on every click.

## Testing
- `tsc --noEmit`
- `biome check`