### PR TITLE
fix: alternating row backgrounds in Manage Packages search

### DIFF
--- a/CHANGELOG-gui.md
+++ b/CHANGELOG-gui.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog].
 ### Removed
 
 ### Fixed
+- Alternating row backgrounds in Manage Packages are broken when filtering with search `#3058`
 
 ### Security
 

--- a/vrc-get-gui/app/_main/projects/manage/-package-list-card.tsx
+++ b/vrc-get-gui/app/_main/projects/manage/-package-list-card.tsx
@@ -320,7 +320,7 @@ export const PackageListCard = memo(function PackageListCard({
 								return null;
 							return (
 								<tr
-									className="even:bg-secondary/30 anchor-none"
+									className="[&:nth-child(even_of_:not([hidden]))]:bg-secondary/30 anchor-none"
 									hidden={!filteredPackageIds.has(row.id)}
 									key={row.id}
 								>
@@ -363,7 +363,7 @@ export const PackageListCard = memo(function PackageListCard({
 								{showHiddenPackages &&
 									hiddenPackages.map((row) => (
 										<tr
-											className="even:bg-secondary/30 anchor-none"
+											className="[&:nth-child(even_of_:not([hidden]))]:bg-secondary/30 anchor-none"
 											hidden={!filteredPackageIds.has(row.id)}
 											key={row.id}
 										>


### PR DESCRIPTION
Search keeps non-matching rows in the DOM with the `hidden` attribute. Tailwind’s `even:` variant uses `:nth-child(even)`, which still counts those hidden rows, so visible results no longer alternate correctly.


Before: <img width="2054" height="1440" alt="image" src="https://github.com/user-attachments/assets/62b30b84-c1b5-4ddf-80d1-395ef8f3bd4e" />

After: 
<img width="2054" height="1440" alt="image" src="https://github.com/user-attachments/assets/38e77a57-9a4b-4d65-adce-c58c706e4db4" />

