### PR TITLE
fix: AppImage cannot run on systemd-less distributions

### DIFF
--- a/CHANGELOG-gui.md
+++ b/CHANGELOG-gui.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog].
 
 ### Fixed
 - Alternating row backgrounds in Manage Packages are broken when filtering with search `#3058`
+- AppImage is incompatible with systemd-less distributions like Void Linux `#3113`
 
 ### Security
 

--- a/vrc-get-gui/bundle/appimage/AppRun
+++ b/vrc-get-gui/bundle/appimage/AppRun
@@ -18,21 +18,15 @@ export LD_LIBRARY_PATH="$appdir/usr/lib/:$appdir/usr/lib/$debian_tuple/:$appdir/
 
 # Distributions without systemd (Void Linux, Artix, Devuan, ...) have no libsystemd.so.0,
 # which our bundled libdbus-1, libwebkit2gtk-4.1 and libjavascriptcoregtk-4.1 all link
-# against, so ALCOM fails to start there. We ship a copy in usr/lib/fallback.
+# against, so ALCOM fails to start there. We ship a copy under usr/lib/fallback.
 #
-# It must only be put on the search path when the host has none: LD_LIBRARY_PATH is searched
-# before the system's ld.so cache, so adding it unconditionally would shadow the host's
-# libsystemd everywhere, which is how the bundled wayland-client broke the EGL/NVIDIA stack
-# in #2596.
+# Every fallback library gets its own directory so exactly the missing ones can be put on
+# the search path. They must not be added otherwise: LD_LIBRARY_PATH is searched before the
+# system's ld.so cache, so adding a directory unconditionally would shadow the host's copy,
+# which is how the bundled wayland-client broke the EGL/NVIDIA stack in #2596.
 has_system_library() {
-	for dir in "/lib/$debian_tuple" "/usr/lib/$debian_tuple" /lib64 /usr/lib64 /lib /usr/lib; do
-		if [ -e "$dir/$1" ]; then
-			return 0
-		fi
-	done
-
-	# musl distributions and NixOS have no ldconfig cache; the directory scan above is all
-	# we can do there, and falling through to the bundled copy is the safe direction.
+	# ld.so.cache is what the loader itself consults, so it is the most accurate check and
+	# it also covers directories configured through /etc/ld.so.conf.d.
 	for ldconfig in ldconfig /sbin/ldconfig /usr/sbin/ldconfig; do
 		if command -v "$ldconfig" > /dev/null 2>&1; then
 			# entries look like: "\tlibsystemd.so.0 (libc6,x86-64) => /lib/..."
@@ -43,11 +37,20 @@ has_system_library() {
 		fi
 	done
 
+	# Not every system has a usable ldconfig cache. Scanning the standard directories as
+	# well keeps us from wrongly deciding the library is missing and then shadowing a host
+	# copy that does exist.
+	for dir in "/lib/$debian_tuple" "/usr/lib/$debian_tuple" /lib64 /usr/lib64 /lib /usr/lib; do
+		if [ -e "$dir/$1" ]; then
+			return 0
+		fi
+	done
+
 	return 1
 }
 
 if ! has_system_library libsystemd.so.0; then
-	export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$appdir/usr/lib/fallback"
+	export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$appdir/usr/lib/fallback/libsystemd0"
 fi
 
 # XDG path

--- a/vrc-get-gui/bundle/appimage/AppRun
+++ b/vrc-get-gui/bundle/appimage/AppRun
@@ -16,6 +16,40 @@ export GST_PLUGIN_SCANNER="$appdir/usr/libexec/gstreamer-1.0/gst-plugin-scanner"
 # LD path, perfer our libraries
 export LD_LIBRARY_PATH="$appdir/usr/lib/:$appdir/usr/lib/$debian_tuple/:$appdir/lib${LD_LIBRARY_PATH+:$LD_LIBRARY_PATH}"
 
+# Distributions without systemd (Void Linux, Artix, Devuan, ...) have no libsystemd.so.0,
+# which our bundled libdbus-1, libwebkit2gtk-4.1 and libjavascriptcoregtk-4.1 all link
+# against, so ALCOM fails to start there. We ship a copy in usr/lib/fallback.
+#
+# It must only be put on the search path when the host has none: LD_LIBRARY_PATH is searched
+# before the system's ld.so cache, so adding it unconditionally would shadow the host's
+# libsystemd everywhere, which is how the bundled wayland-client broke the EGL/NVIDIA stack
+# in #2596.
+has_system_library() {
+	for dir in "/lib/$debian_tuple" "/usr/lib/$debian_tuple" /lib64 /usr/lib64 /lib /usr/lib; do
+		if [ -e "$dir/$1" ]; then
+			return 0
+		fi
+	done
+
+	# musl distributions and NixOS have no ldconfig cache; the directory scan above is all
+	# we can do there, and falling through to the bundled copy is the safe direction.
+	for ldconfig in ldconfig /sbin/ldconfig /usr/sbin/ldconfig; do
+		if command -v "$ldconfig" > /dev/null 2>&1; then
+			# entries look like: "\tlibsystemd.so.0 (libc6,x86-64) => /lib/..."
+			if "$ldconfig" -p 2> /dev/null | grep -q "^[[:space:]]*$1 "; then
+				return 0
+			fi
+			break
+		fi
+	done
+
+	return 1
+}
+
+if ! has_system_library libsystemd.so.0; then
+	export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$appdir/usr/lib/fallback"
+fi
+
 # XDG path
 export XDG_DATA_DIRS="$appdir/usr/shere:${XDG_DATA_DIRS:-/usr/local/share/:/usr/share/}";
 

--- a/xtask/src/bundle_alcom/appimage.rs
+++ b/xtask/src/bundle_alcom/appimage.rs
@@ -5,6 +5,7 @@ use crate::utils::command::CommandExt;
 use crate::utils::rustc::rustc_host_triple;
 use crate::utils::{download_file_cached, make_executable, target_arch};
 use anyhow::{Context, Result};
+use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command as ProcessCommand;
@@ -218,6 +219,9 @@ pub fn prepare_system_libraries(ctx: &BundleContext<'_>, appimage_root: &Path) -
     fs::remove_dir_all(appimage_root.join("usr/share/lintian"))
         .context("removing enchant gstreamer helper")?;
 
+    prepare_fallback_libraries(appimage_root, &required_packages, &system_packages)
+        .context("copying fallback libraries")?;
+
     // replace '/usr/lib' with '././/lib' for webkit and enchant.
     // Those libraries do not support relocation through env variable so we replace with
     // relative path and running under appimage /usr to prevent problems
@@ -231,6 +235,97 @@ pub fn prepare_system_libraries(ctx: &BundleContext<'_>, appimage_root: &Path) -
                 name.starts_with(b"libenchant") || name.starts_with(b"libwebkit")
             }),
     )?;
+
+    Ok(())
+}
+
+/// Libraries that are normally provided by the system, but are missing entirely on some
+/// distributions. They are copied into `usr/lib/fallback`, which AppRun adds to
+/// `LD_LIBRARY_PATH` only when the host does not provide them.
+///
+/// These must NOT be bundled the usual way: `LD_LIBRARY_PATH` is searched before the
+/// system's `ld.so` cache, so a normally-bundled copy would shadow the host's library on
+/// every distribution that does have it. That is the same failure mode as #2596, where the
+/// bundled wayland-client conflicted with the host's EGL/NVIDIA stack.
+static FALLBACK_LIBRARIES: &[&str] = &[
+    // systemd-less distributions (Void Linux, Artix, Devuan, ...) have no libsystemd.so.0,
+    // which our bundled libdbus-1, libwebkit2gtk-4.1 and libjavascriptcoregtk-4.1 all link.
+    "libsystemd0",
+];
+
+/// Copies [`FALLBACK_LIBRARIES`] and their dependencies into `usr/lib/fallback`.
+///
+/// Shared objects are flattened into that single directory so the dynamic loader finds them
+/// through `LD_LIBRARY_PATH`. Packages already bundled normally are skipped.
+fn prepare_fallback_libraries(
+    appimage_root: &Path,
+    bundled_packages: &[String],
+    system_packages: &HashSet<String>,
+) -> Result<()> {
+    // the fallback libraries are system libraries, so they have to be excluded from the
+    // system package set for the dependency walk to consider them at all.
+    let mut lookup_packages = system_packages.clone();
+    for library in FALLBACK_LIBRARIES {
+        lookup_packages.remove(*library);
+    }
+
+    let packages = list_deps::collect_dependency_packages(
+        FALLBACK_LIBRARIES.iter().map(|x| (*x).to_owned()),
+        &lookup_packages,
+    )
+    .context("resolving dependencies of fallback libraries")?;
+
+    let packages = (packages.into_iter())
+        .filter(|package| !bundled_packages.contains(package))
+        .collect::<Vec<_>>();
+
+    println!("Bundling the following libraries as a fallback");
+    for package in &packages {
+        println!("  {}", package);
+    }
+
+    let files = list_deps::collect_files_to_bundle(&packages)?;
+
+    let fallback_dir = appimage_root.join("usr/lib/fallback");
+    fs::create_dir_all(&fallback_dir).context("creating fallback directory")?;
+
+    for path in &files {
+        let name = match Path::new(path).file_name().and_then(|name| name.to_str()) {
+            Some(name) if name.contains(".so") => name,
+            // documentation, changelogs and the like are not needed
+            _ => continue,
+        };
+
+        let absolute = Path::new("/").join(path);
+        let metadata = absolute
+            .symlink_metadata()
+            .context("reading symlink metadata")?;
+
+        if metadata.is_dir() {
+            continue;
+        }
+
+        let destination = fallback_dir.join(name);
+
+        if metadata.is_symlink() {
+            // flatten the link target too, everything lives in one directory now
+            let link = fs::read_link(&absolute).context("reading symlink")?;
+            let target = link
+                .file_name()
+                .expect("symlink target should have a file name");
+            cfg_select! {
+                unix => {
+                    std::os::unix::fs::symlink(target, &destination)
+                        .with_context(|| format!("copying {path}"))?;
+                }
+                _ => {
+                    panic!("symlink is not available");
+                }
+            }
+        } else {
+            fs::copy(&absolute, &destination).with_context(|| format!("copying {path}"))?;
+        }
+    }
 
     Ok(())
 }
@@ -347,8 +442,10 @@ mod list_deps {
         "libnghttp2-14",
         "libpsl5",
         "libsqlite3-0",
-        // include libsystemd0 since systemd-less distributions (void linux, artix, devuan, ...)
-        // do not provide libsystemd.so.0 at all
+        // libsystemd0 stays a system library so it never shadows the host's copy.
+        // It is additionally bundled into usr/lib/fallback for systemd-less
+        // distributions; see FALLBACK_LIBRARIES.
+        "libsystemd0",
         "libtasn1-6",
         "libwayland-client0",
         "libwayland-server0",

--- a/xtask/src/bundle_alcom/appimage.rs
+++ b/xtask/src/bundle_alcom/appimage.rs
@@ -347,7 +347,8 @@ mod list_deps {
         "libnghttp2-14",
         "libpsl5",
         "libsqlite3-0",
-        "libsystemd0",
+        // include libsystemd0 since systemd-less distributions (void linux, artix, devuan, ...)
+        // do not provide libsystemd.so.0 at all
         "libtasn1-6",
         "libwayland-client0",
         "libwayland-server0",

--- a/xtask/src/bundle_alcom/appimage.rs
+++ b/xtask/src/bundle_alcom/appimage.rs
@@ -240,53 +240,76 @@ pub fn prepare_system_libraries(ctx: &BundleContext<'_>, appimage_root: &Path) -
 }
 
 /// Libraries that are normally provided by the system, but are missing entirely on some
-/// distributions. They are copied into `usr/lib/fallback`, which AppRun adds to
-/// `LD_LIBRARY_PATH` only when the host does not provide them.
+/// distributions. Each one is copied into its own `usr/lib/fallback/<package>` directory,
+/// which AppRun adds to `LD_LIBRARY_PATH` only when the host does not provide it.
 ///
 /// These must NOT be bundled the usual way: `LD_LIBRARY_PATH` is searched before the
 /// system's `ld.so` cache, so a normally-bundled copy would shadow the host's library on
 /// every distribution that does have it. That is the same failure mode as #2596, where the
 /// bundled wayland-client conflicted with the host's EGL/NVIDIA stack.
+///
+/// A directory per package is what lets AppRun put exactly the missing libraries on the
+/// search path; with a single shared directory, one missing library would drag every other
+/// fallback library onto it as well and shadow the host's copies of those.
 static FALLBACK_LIBRARIES: &[&str] = &[
     // systemd-less distributions (Void Linux, Artix, Devuan, ...) have no libsystemd.so.0,
     // which our bundled libdbus-1, libwebkit2gtk-4.1 and libjavascriptcoregtk-4.1 all link.
+    //
+    // None of the four symbols those libraries actually use require systemd to be running,
+    // or any systemd configuration to be present:
+    //   sd_listen_fds   reads $LISTEN_PID / $LISTEN_FDS and returns 0 when they are unset
+    //   sd_is_socket    is an fstat on a file descriptor
+    //   sd_journal_send writes to /run/systemd/journal/socket and gives up when it is absent
+    //                   (sd_journal_send_with_location likewise)
+    // Measured on a host with no systemd and no /run/systemd/journal/socket: all of them
+    // return 0 and none of them crash, and sd_booted() returns 0, i.e. the library detects
+    // the situation and reports it rather than misbehaving.
     "libsystemd0",
 ];
 
-/// Copies [`FALLBACK_LIBRARIES`] and their dependencies into `usr/lib/fallback`.
-///
-/// Shared objects are flattened into that single directory so the dynamic loader finds them
-/// through `LD_LIBRARY_PATH`. Packages already bundled normally are skipped.
+/// Copies every [`FALLBACK_LIBRARIES`] entry into its own `usr/lib/fallback/<package>`.
 fn prepare_fallback_libraries(
     appimage_root: &Path,
     bundled_packages: &[String],
     system_packages: &HashSet<String>,
 ) -> Result<()> {
-    // the fallback libraries are system libraries, so they have to be excluded from the
-    // system package set for the dependency walk to consider them at all.
-    let mut lookup_packages = system_packages.clone();
     for library in FALLBACK_LIBRARIES {
-        lookup_packages.remove(*library);
+        prepare_fallback_library(appimage_root, library, bundled_packages, system_packages)
+            .with_context(|| format!("copying fallback library {library}"))?;
     }
+    Ok(())
+}
 
-    let packages = list_deps::collect_dependency_packages(
-        FALLBACK_LIBRARIES.iter().map(|x| (*x).to_owned()),
-        &lookup_packages,
-    )
-    .context("resolving dependencies of fallback libraries")?;
+/// Copies `library` and its dependencies into `usr/lib/fallback/<library>`.
+///
+/// Shared objects are flattened into that directory so the dynamic loader finds them through
+/// `LD_LIBRARY_PATH`. Packages already bundled normally are skipped.
+fn prepare_fallback_library(
+    appimage_root: &Path,
+    library: &str,
+    bundled_packages: &[String],
+    system_packages: &HashSet<String>,
+) -> Result<()> {
+    // the fallback library is a system library, so it has to be excluded from the system
+    // package set for the dependency walk to consider it at all.
+    let mut lookup_packages = system_packages.clone();
+    lookup_packages.remove(library);
+
+    let packages = list_deps::collect_dependency_packages([library.to_owned()], &lookup_packages)
+        .context("resolving dependencies of fallback library")?;
 
     let packages = (packages.into_iter())
         .filter(|package| !bundled_packages.contains(package))
         .collect::<Vec<_>>();
 
-    println!("Bundling the following libraries as a fallback");
+    println!("Bundling the following libraries as a fallback for {library}");
     for package in &packages {
         println!("  {}", package);
     }
 
     let files = list_deps::collect_files_to_bundle(&packages)?;
 
-    let fallback_dir = appimage_root.join("usr/lib/fallback");
+    let fallback_dir = appimage_root.join("usr/lib/fallback").join(library);
     fs::create_dir_all(&fallback_dir).context("creating fallback directory")?;
 
     for path in &files {
@@ -442,9 +465,7 @@ mod list_deps {
         "libnghttp2-14",
         "libpsl5",
         "libsqlite3-0",
-        // libsystemd0 stays a system library so it never shadows the host's copy.
-        // It is additionally bundled into usr/lib/fallback for systemd-less
-        // distributions; see FALLBACK_LIBRARIES.
+        // For systemd-less distributions compatibility, we additionally ship a copy of libsystemd.so.0 as fallback. see FALLBACK_LIBRARIES above
         "libsystemd0",
         "libtasn1-6",
         "libwayland-client0",


### PR DESCRIPTION
## Problem

ALCOM's AppImage fails to start on distributions that do not use systemd:

```
/tmp/.mount_alcom-XXXXXX/usr/bin/ALCOM: error while loading shared libraries:
libsystemd.so.0: cannot open shared object file: No such file or directory
```

Three bundled libraries link against `libsystemd.so.0`:

- `libwebkit2gtk-4.1.so.0` — `sd_journal_send`, `sd_journal_send_with_location`
- `libjavascriptcoregtk-4.1.so.0` — `sd_journal_send_with_location`
- `libdbus-1.so.3` — `sd_is_socket`, `sd_listen_fds`

On Debian/Ubuntu/Fedora the host provides it. Distributions without systemd (Void Linux, Artix, Devuan, ...) provide no `libsystemd.so.0` at all, so the AppImage cannot start.

## Fix

`libsystemd0` **stays** in `SYSTEM_LIBRARIES`, so it is never bundled in the normal way. A copy is additionally placed in `usr/lib/fallback/libsystemd0`, and `AppRun` adds that directory to `LD_LIBRARY_PATH` **only when the host provides no `libsystemd.so.0`**.

This means the bundled copy and a host copy can never be loaded into the same process. On every distribution that has systemd, behaviour is unchanged. The [#2596](https://github.com/vrc-get/vrc-get/issues/2596) failure mode — a bundled library mixing with the host's in one process, as the bundled wayland-client did with the host EGL/NVIDIA stack — is structurally impossible here rather than merely unlikely.

Two details worth noting:

- The conditional is necessary, not cosmetic. `LD_LIBRARY_PATH` is searched *before* the `ld.so` cache, so simply appending the directory would shadow the host's library everywhere. `AppRun` checks `ldconfig -p` first, since the cache is what the loader itself consults and covers `/etc/ld.so.conf.d` paths, then falls back to scanning the standard library directories for systems without a usable cache.
- Each fallback library gets its own directory. With a single shared one, a host missing library A would put library B on the search path too and shadow the host's copy of B.

`FALLBACK_LIBRARIES` is a list, so if another system library turns out to be missing somewhere it can be handled the same way without bundling it for everyone.

### About libsystemd without systemd

None of the four symbols in use require systemd to be running or any systemd configuration to exist. `sd_listen_fds` reads `$LISTEN_PID`/`$LISTEN_FDS` and returns 0 when unset; `sd_is_socket` is an `fstat` on a file descriptor; the journal calls write to `/run/systemd/journal/socket` and give up when it is absent.

Measured on a host with no systemd and no `/run/systemd/journal/socket`, loading the shipped jammy `libsystemd.so.0` directly:

```
dlopen libsystemd.so.0 : OK
sd_listen_fds(0)       : 0
sd_journal_send(...)   : 0
sd_is_socket(0,0,0,-1) : 0
sd_booted()            : 0
```

Nothing crashes, and `sd_booted()` returning 0 shows the library detects the situation and reports it rather than misbehaving.

## Testing

Tested on Void Linux x86_64 (runit, no systemd, `elogind` only).

Because the jammy-based build pipeline cannot run on Void, I reproduced the resulting AppDir by hand: the released `alcom-1.1.8-x86_64.AppImage` with `libsystemd.so.0` (249.11-0ubuntu3.21), `liblz4.so.1` (1.9.3-2build2) and `libzstd.so.1` (1.4.8+dfsg-3build1) placed in `usr/lib/fallback/libsystemd0/`, nothing added to the normal library directory, and this `AppRun`.

**Host without libsystemd** — starts and runs normally. `LD_TRACE_LOADED_OBJECTS` confirms the fallback is used:

```
libsystemd.so.0 => <appdir>/usr/lib/fallback/libsystemd0/libsystemd.so.0
libzstd.so.1    => <appdir>/usr/lib/fallback/libsystemd0/libzstd.so.1
liblz4.so.1     => <appdir>/usr/lib/fallback/libsystemd0/liblz4.so.1
```

**Host with the library** — simulated by pointing the same check at `libelogind.so.0`, which does exist on this machine. The fallback directory is correctly *not* added and ALCOM fails with the original error, which is the intended behaviour and shows the directory really is gated.

The detection function was checked against `libsystemd.so.0` (absent), `libelogind.so.0` and `libc.so.6` (both found) and a nonexistent library (absent) — no false positives or negatives.

`cargo fmt` and `cargo clippy -p xtask` are clean.

---

Disclosure: this patch was written with the help of Claude (an AI agent), which is reflected in the commit trailers. I have tested the result on my own machine as described above.
