### PR TITLE
feat: add dev language switcher to sidebar and keyboard shortcuts

### DIFF
--- a/vrc-get-gui/components/SideBar.tsx
+++ b/vrc-get-gui/components/SideBar.tsx
@@ -10,12 +10,15 @@ import {
 	AlignLeft,
 	CircleAlert,
 	Info,
+	Languages,
 	List,
 	Package,
 	Settings,
 	SwatchBook,
 } from "lucide-react";
 import type React from "react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import {
 	GuiAnimationSwitch,
 	GuiCompactSwitch,
@@ -42,8 +45,9 @@ import {
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { commands } from "@/lib/bindings";
+import { useDocumentEvent } from "@/lib/events";
 import { useGlobalInfo } from "@/lib/global-info";
-import { tc } from "@/lib/i18n";
+import { cycleLanguage, languageAt, tc } from "@/lib/i18n";
 import { toastNormal } from "@/lib/toast";
 
 export function SideBar({ className }: { className?: string }) {
@@ -91,6 +95,7 @@ export function SideBar({ className }: { className?: string }) {
 					/>
 				)}
 				{isDev && <StyleQuickAccess />}
+				{isDev && <DevLanguageSwitcher />}
 				<div className={"grow"} />
 				{isBadHostName.data && <BadHostNameDialogButton />}
 				<SideBarButton
@@ -178,16 +183,47 @@ function DevRestartSetupButton() {
 	);
 }
 
+function DevLanguageSwitcher() {
+	const { t } = useTranslation();
+	const { osType } = useGlobalInfo();
+	const [shiftHeld, setShiftHeld] = useState(false);
+	useDocumentEvent("keydown", (e) => setShiftHeld(e.shiftKey), []);
+	useDocumentEvent("keyup", (e) => setShiftHeld(e.shiftKey), []);
+
+	const mod = osType === "Darwin" ? "Cmd" : "Ctrl";
+	const target = t("settings:langName", {
+		lng: languageAt(shiftHeld ? -1 : 1),
+	});
+
+	return (
+		<SideBarButton
+			icon={Languages}
+			tooltip={
+				<>
+					{`Click to ${shiftHeld ? "previous" : "next"} language: ${target}`}
+					<br />
+					{`${mod}+L: next language, ${mod}+Shift+L: previous language`}
+				</>
+			}
+			onClick={(e) => void cycleLanguage(e.shiftKey ? -1 : 1)}
+		>
+			{`Current: ${t("settings:langName")} (dev only)`}
+		</SideBarButton>
+	);
+}
+
 function SideBarButton({
 	icon,
 	showIconOnlyWhenCompact,
 	className,
+	tooltip,
 	children,
 	...props
 }: {
 	icon: React.ComponentType<{ className?: string }>;
 	showIconOnlyWhenCompact?: boolean;
 	className?: string;
+	tooltip?: React.ReactNode;
 	children: React.ReactNode;
 } & React.ComponentProps<typeof Button>) {
 	const IconElement = icon;
@@ -207,7 +243,7 @@ function SideBarButton({
 					<span className="compact:hidden">{children}</span>
 				</Button>
 			</TooltipTrigger>
-			<TooltipContent side="right">{children}</TooltipContent>
+			<TooltipContent side="right">{tooltip ?? children}</TooltipContent>
 		</Tooltip>
 	);
 }

--- a/vrc-get-gui/components/SideBar.tsx
+++ b/vrc-get-gui/components/SideBar.tsx
@@ -10,18 +10,16 @@ import {
 	AlignLeft,
 	CircleAlert,
 	Info,
-	Languages,
 	List,
 	Package,
 	Settings,
 	SwatchBook,
 } from "lucide-react";
 import type React from "react";
-import { useState } from "react";
-import { useTranslation } from "react-i18next";
 import {
 	GuiAnimationSwitch,
 	GuiCompactSwitch,
+	LanguageSelector,
 	ThemeSelector,
 } from "@/components/common-setting-parts";
 import { Button } from "@/components/ui/button";
@@ -45,9 +43,8 @@ import {
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { commands } from "@/lib/bindings";
-import { useDocumentEvent } from "@/lib/events";
 import { useGlobalInfo } from "@/lib/global-info";
-import { cycleLanguage, languageAt, tc } from "@/lib/i18n";
+import { tc } from "@/lib/i18n";
 import { toastNormal } from "@/lib/toast";
 
 export function SideBar({ className }: { className?: string }) {
@@ -95,7 +92,6 @@ export function SideBar({ className }: { className?: string }) {
 					/>
 				)}
 				{isDev && <StyleQuickAccess />}
-				{isDev && <DevLanguageSwitcher />}
 				<div className={"grow"} />
 				{isBadHostName.data && <BadHostNameDialogButton />}
 				<SideBarButton
@@ -183,35 +179,6 @@ function DevRestartSetupButton() {
 	);
 }
 
-function DevLanguageSwitcher() {
-	const { t } = useTranslation();
-	const { osType } = useGlobalInfo();
-	const [shiftHeld, setShiftHeld] = useState(false);
-	useDocumentEvent("keydown", (e) => setShiftHeld(e.shiftKey), []);
-	useDocumentEvent("keyup", (e) => setShiftHeld(e.shiftKey), []);
-
-	const mod = osType === "Darwin" ? "Cmd" : "Ctrl";
-	const target = t("settings:langName", {
-		lng: languageAt(shiftHeld ? -1 : 1),
-	});
-
-	return (
-		<SideBarButton
-			icon={Languages}
-			tooltip={
-				<>
-					{`Click to ${shiftHeld ? "previous" : "next"} language: ${target}`}
-					<br />
-					{`${mod}+L: next language, ${mod}+Shift+L: previous language`}
-				</>
-			}
-			onClick={(e) => void cycleLanguage(e.shiftKey ? -1 : 1)}
-		>
-			{`Current: ${t("settings:langName")} (dev only)`}
-		</SideBarButton>
-	);
-}
-
 function SideBarButton({
 	icon,
 	showIconOnlyWhenCompact,
@@ -256,7 +223,8 @@ export function StyleQuickAccess() {
 					Style Settings (dev only)
 				</SideBarButton>
 			</PopoverTrigger>
-			<PopoverContent>
+			<PopoverContent className="w-96 flex flex-col gap-3 [&>label]:flex-col [&>label]:items-start [&>div]:space-y-1">
+				<LanguageSelector />
 				<ThemeSelector />
 				<GuiAnimationSwitch />
 				<GuiCompactSwitch />

--- a/vrc-get-gui/components/SideBar.tsx
+++ b/vrc-get-gui/components/SideBar.tsx
@@ -183,14 +183,12 @@ function SideBarButton({
 	icon,
 	showIconOnlyWhenCompact,
 	className,
-	tooltip,
 	children,
 	...props
 }: {
 	icon: React.ComponentType<{ className?: string }>;
 	showIconOnlyWhenCompact?: boolean;
 	className?: string;
-	tooltip?: React.ReactNode;
 	children: React.ReactNode;
 } & React.ComponentProps<typeof Button>) {
 	const IconElement = icon;
@@ -210,7 +208,7 @@ function SideBarButton({
 					<span className="compact:hidden">{children}</span>
 				</Button>
 			</TooltipTrigger>
-			<TooltipContent side="right">{tooltip ?? children}</TooltipContent>
+			<TooltipContent side="right">{children}</TooltipContent>
 		</Tooltip>
 	);
 }

--- a/vrc-get-gui/components/providers.tsx
+++ b/vrc-get-gui/components/providers.tsx
@@ -12,8 +12,8 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import type { LogEntry, TauriImportTemplateResult } from "@/lib/bindings";
 import { commands } from "@/lib/bindings";
 import { DialogRoot, openSingleDialog } from "@/lib/dialog";
-import { isFindKey, useDocumentEvent } from "@/lib/events";
-import { tc } from "@/lib/i18n";
+import { isFindKey, isLanguageCycleKey, useDocumentEvent } from "@/lib/events";
+import { cycleLanguage, tc } from "@/lib/i18n";
 import { processResult } from "@/lib/import-templates";
 import { queryClient } from "@/lib/query-client";
 import {
@@ -120,6 +120,10 @@ export function Providers({ children }: { children: React.ReactNode }) {
 		(e) => {
 			if (isFindKey(e)) {
 				e.preventDefault();
+			}
+			if (import.meta.env.DEV && isLanguageCycleKey(e)) {
+				e.preventDefault();
+				void cycleLanguage(e.shiftKey ? -1 : 1);
 			}
 		},
 		[],

--- a/vrc-get-gui/lib/events.ts
+++ b/vrc-get-gui/lib/events.ts
@@ -32,3 +32,13 @@ export function isFindKey(
 	if ((globalInfo.osType === "Darwin" ? e.metaKey : e.ctrlKey) && e.key === "f")
 		return true;
 }
+
+// dev-only: Ctrl+L (Cmd+L on macOS) cycles the language, Shift reverses it.
+export function isLanguageCycleKey(
+	e: Pick<KeyboardEvent, "code" | "metaKey" | "ctrlKey">,
+) {
+	return (
+		(globalInfo.osType === "Darwin" ? e.metaKey : e.ctrlKey) &&
+		e.code === "KeyL"
+	);
+}

--- a/vrc-get-gui/lib/i18n.ts
+++ b/vrc-get-gui/lib/i18n.ts
@@ -50,7 +50,9 @@ export const languages = Object.keys(languageResources);
 
 // dev-only language switcher helpers (see SideBar.tsx / providers.tsx)
 export function languageAt(delta: number): string {
-	return languages.at((languages.indexOf(i18next.language) + delta) % languages.length)!;
+	const index =
+		(languages.indexOf(i18next.language) + delta) % languages.length;
+	return languages.at(index) ?? languages[0];
 }
 
 export async function cycleLanguage(delta: number) {

--- a/vrc-get-gui/lib/i18n.ts
+++ b/vrc-get-gui/lib/i18n.ts
@@ -50,9 +50,7 @@ export const languages = Object.keys(languageResources);
 
 // dev-only language switcher helpers (see SideBar.tsx / providers.tsx)
 export function languageAt(delta: number): string {
-	return languages[
-		(languages.indexOf(i18next.language) + delta) % languages.length
-	];
+	return languages.at((languages.indexOf(i18next.language) + delta) % languages.length)!;
 }
 
 export async function cycleLanguage(delta: number) {

--- a/vrc-get-gui/lib/i18n.ts
+++ b/vrc-get-gui/lib/i18n.ts
@@ -3,7 +3,9 @@ import React from "react";
 import { initReactI18next, Trans, useTranslation } from "react-i18next";
 import type { TransProps } from "react-i18next/TransWithoutContext";
 import { ExternalLink } from "@/components/ExternalLink";
+import { commands } from "@/lib/bindings";
 import globalInfo from "@/lib/global-info";
+import { queryClient } from "@/lib/query-client";
 import deJson from "@/locales/de.json5";
 import enJson from "@/locales/en.json5";
 import esJson from "@/locales/es.json5";
@@ -45,6 +47,19 @@ i18next.changeLanguage(globalInfo.language);
 
 export default i18next;
 export const languages = Object.keys(languageResources);
+
+// dev-only language switcher helpers (see SideBar.tsx / providers.tsx)
+export function languageAt(delta: number) {
+	const index = languages.indexOf(i18next.language);
+	return languages[(index + delta + languages.length) % languages.length];
+}
+
+export async function cycleLanguage(delta: number) {
+	const next = languageAt(delta);
+	await i18next.changeLanguage(next);
+	await commands.environmentSetLanguage(next);
+	await queryClient.invalidateQueries({ queryKey: ["environmentLanguage"] });
+}
 
 function VGTrans(props: TransProps<string>) {
 	const components = {

--- a/vrc-get-gui/lib/i18n.ts
+++ b/vrc-get-gui/lib/i18n.ts
@@ -50,8 +50,7 @@ export const languages = Object.keys(languageResources);
 
 // dev-only language switcher helpers (see SideBar.tsx / providers.tsx)
 export function languageAt(delta: number) {
-	const index = languages.indexOf(i18next.language);
-	return languages[(index + delta + languages.length) % languages.length];
+	return languages.at((languages.indexOf(i18next.language) + delta ) % languages.length);
 }
 
 export async function cycleLanguage(delta: number) {

--- a/vrc-get-gui/lib/i18n.ts
+++ b/vrc-get-gui/lib/i18n.ts
@@ -49,8 +49,10 @@ export default i18next;
 export const languages = Object.keys(languageResources);
 
 // dev-only language switcher helpers (see SideBar.tsx / providers.tsx)
-export function languageAt(delta: number) {
-	return languages.at((languages.indexOf(i18next.language) + delta ) % languages.length);
+export function languageAt(delta: number): string {
+	return languages[
+		(languages.indexOf(i18next.language) + delta) % languages.length
+	];
 }
 
 export async function cycleLanguage(delta: number) {


### PR DESCRIPTION
close #3159

## 操作方法
サイドバーのボタンをクリックすると次の言語に切り替わります。（Shift 押しながらクリックで方向が反転します）
`Ctrl + L` でも次の言語に切り替わります。（Shift 押しながらショートカット入力で方向が反転します）

言語別に UI のビジュアルを確認する作業で使われることを想定しているので、少し癖が強い操作感になっていますが、改善点などあれば教えてください。
